### PR TITLE
Improve engine docstrings

### DIFF
--- a/src/farkle/engine.py
+++ b/src/farkle/engine.py
@@ -49,7 +49,7 @@ class FarklePlayer:
     score: int = 0
     has_scored: bool = False  # entered game (≥500) flag
     rng: np.random.Generator = field(default_factory=np.random.default_rng, repr=False)
-    
+
     # counters
     n_farkles: int = 0
     n_rolls: int = 0
@@ -60,10 +60,10 @@ class FarklePlayer:
     n_smart_one_dice: int = 0
     n_hot_dice: int = 0
     strategy_str: str = field(init=False, repr=False)
-    
+
     def __post_init__(self):
         object.__setattr__(self, "strategy_str", str(self.strategy))
-        
+
     # ----------------------------- helpers -----------------------------
     def _roll(self, n: int) -> DiceRoll:
         """Produce n dice using this player's RNG.
@@ -119,18 +119,18 @@ class FarklePlayer:
             rolls_this_turn += 1
 
             # 2) Compute points from this roll, after applying Smart‐5/Smart‐1 discards
-            pts, used, reroll, d5, d1 = default_score( # type: ignore
-                dice_roll = roll,
-                turn_score_pre = turn_score,
-                smart_five = self.strategy.smart_five,
-                smart_one = self.strategy.smart_one,
-                score_threshold = self.strategy.score_threshold,
-                dice_threshold = self.strategy.dice_threshold,
-                consider_score = self.strategy.consider_score,
-                consider_dice = self.strategy.consider_dice,
-                require_both = self.strategy.require_both,
-                prefer_score = self.strategy.prefer_score,
-                return_discards = True
+            pts, used, reroll, d5, d1 = default_score(  # type: ignore
+                dice_roll=roll,
+                turn_score_pre=turn_score,
+                smart_five=self.strategy.smart_five,
+                smart_one=self.strategy.smart_one,
+                score_threshold=self.strategy.score_threshold,
+                dice_threshold=self.strategy.dice_threshold,
+                consider_score=self.strategy.consider_score,
+                consider_dice=self.strategy.consider_dice,
+                require_both=self.strategy.require_both,
+                prefer_score=self.strategy.prefer_score,
+                return_discards=True,
             )
 
             # 3) If pts == 0, that's a Farkle: bust, lose all points this turn, and end turn
@@ -141,7 +141,7 @@ class FarklePlayer:
 
             # 4) Otherwise, accumulate the points from this roll
             turn_score += pts
-            
+
             # 4.5) Update smart_five and smart_one tracking
             if d5:
                 self.smart_five_uses += 1
@@ -149,17 +149,17 @@ class FarklePlayer:
             if d1:
                 self.smart_one_uses += 1
                 self.n_smart_one_dice += d1
-            
+
             # 5) “Hot dice” logic: if all dice in roll scored (used == len(roll)),
             #    and reroll == 0, that means you get to roll all 6 dice again.
             #    Otherwise, you roll reroll dice next.
             dice = 6 if (used == len(roll) and reroll == 0) else reroll
-            
+
             # 5.5) Hot dice short circuit
             if self.strategy.auto_hot_dice and dice == 6:
                 self.n_hot_dice += 1
                 continue  # force another throw
-            
+
             # 6-A) If we’re in the final round and have already won, stop.
             running_total = self.score + turn_score
             score_needed = max(0, target_score - running_total)
@@ -176,15 +176,15 @@ class FarklePlayer:
             #      - has_scored = whether we’ve ever scored ≥500 on a previous turn
             #      - score_needed = how many more points (from banked + turn_score) we need to reach target_score
             keep_rolling = self.strategy.decide(
-                turn_score = turn_score,
-                dice_left = dice,
-                has_scored = self.has_scored,
-                score_needed = score_needed,
-                final_round = final_round,
-                score_to_beat= score_to_beat,
-                running_total= running_total,
+                turn_score=turn_score,
+                dice_left=dice,
+                has_scored=self.has_scored,
+                score_needed=score_needed,
+                final_round=final_round,
+                score_to_beat=score_to_beat,
+                running_total=running_total,
             )
-        
+
             # 6-C) Override the strategy if we’re still behind in the final round.
             if final_round and running_total <= score_to_beat:
                 keep_rolling = True
@@ -206,28 +206,27 @@ class FarklePlayer:
 # Game-level structures
 # ---------------------------------------------------------------------------
 
+
 @dataclass(slots=True)
 class GameStats:
-    """Summary statistics describing a completed game.
+    """Aggregate results of one game.
 
-    Inputs
-    ------
-    winner
-        Name of the winning player.
-    winning_score
-        Score achieved by the winner.
+    Attributes
+    ----------
+    n_players
+        Number of participants.
+    table_seed
+        Seed used for the table RNG.
     n_rounds
-        Number of rounds played.
-    per_player
-        Stats for each player keyed by name.
-    winner_data
-        Stats for the winner only.
-
-    Returns
-    -------
-    GameMetrics
-        New dataclass instance populated with results.
+        Rounds played before a winner emerged.
+    total_rolls
+        Combined dice rolls for all players.
+    total_farkles
+        Total number of Farkles rolled.
+    margin
+        Points separating first and second place.
     """
+
     n_players: int
     table_seed: int
     n_rounds: int
@@ -239,6 +238,16 @@ class GameStats:
 
 @dataclass(slots=True)
 class GameMetrics:
+    """Per-game statistics keyed by player name.
+
+    Attributes
+    ----------
+    players
+        Mapping from player name to :class:`PlayerStats`.
+    game
+        :class:`GameStats` summarising the overall session.
+    """
+
     players: Dict[str, PlayerStats]
     game: GameStats
 
@@ -265,13 +274,39 @@ class GameMetrics:
 
 @dataclass(slots=True)
 class PlayerStats:
+    """Statistics for a single player.
+
+    Attributes
+    ----------
+    score
+        Final score for the game.
+    farkles
+        Number of times the player farkled.
+    rolls
+        Dice rolls taken across all turns.
+    highest_turn
+        Highest single-turn score.
+    strategy
+        String representation of the strategy used.
+    rank
+        Finishing position (1 for the winner).
+    loss_margin
+        Point difference from the winner (``0`` if they won).
+    smart_five_uses, n_smart_five_dice
+        Counts for Smart‑5 heuristic usage and dice removed.
+    smart_one_uses, n_smart_one_dice
+        Counts for Smart‑1 heuristic usage and dice removed.
+    hot_dice
+        Number of hot-dice rerolls.
+    """
+
     score: int
     farkles: int
     rolls: int
     highest_turn: int
     strategy: str
-    rank: int # 1 = winner
-    loss_margin: int # 0 for winner, >0 otherwise
+    rank: int  # 1 = winner
+    loss_margin: int  # 0 for winner, >0 otherwise
     smart_five_uses: int = 0
     n_smart_five_dice: int = 0
     smart_one_uses: int = 0
@@ -282,7 +317,21 @@ class PlayerStats:
 class FarkleGame:
     """Driver for a *single* Farkle game."""
 
-    def __init__(self, players: Sequence[FarklePlayer], *, target_score: int = 10_000, table_seed: int = 0) -> None:
+    def __init__(
+        self, players: Sequence[FarklePlayer], *, target_score: int = 10_000, table_seed: int = 0
+    ) -> None:
+        """Create a new game instance.
+
+        Inputs
+        ------
+        players
+            Participants in turn order.
+        target_score
+            Score that triggers the final round.
+        table_seed
+            Seed for any table-level randomness.
+        """
+
         self.players: List[FarklePlayer] = list(players)
         self.target_score: int = target_score
         self.table_seed = table_seed
@@ -308,36 +357,41 @@ class FarkleGame:
             rounds += 1
             for p in self.players:
                 p.take_turn(
-                    self.target_score,  # This is that vestigial stat 
-                    final_round = final_round,
-                    score_to_beat = score_to_beat,
+                    self.target_score,  # This is that vestigial stat
+                    final_round=final_round,
+                    score_to_beat=score_to_beat,
                 )
                 # First trigger starts the final round
                 if not final_round and p.score >= self.target_score:
                     final_round = True
                     score_to_beat = p.score
                     triggering_player = p
-                    final_players = [player for player in self.players if player != triggering_player]
-                
+                    final_players = [
+                        player for player in self.players if player != triggering_player
+                    ]
+
                 if final_round:
-                    for player in final_players:  # All other players have chance to beat the first tentative winner
-                                                  # It's not fair, but it's the rules
-                        player.take_turn(target_score=self.target_score,
-                                         final_round=True,
-                                         score_to_beat=score_to_beat)
-                # During the final round update the bar whenever someone
-                #     jumps ahead (so later players know what they must beat).
+                    for player in (
+                        final_players
+                    ):  # All other players have chance to beat the first tentative winner
+                        # It's not fair, but it's the rules
+                        player.take_turn(
+                            target_score=self.target_score,
+                            final_round=True,
+                            score_to_beat=score_to_beat,
+                        )
+                        # During the final round update the bar whenever someone
+                        #     jumps ahead (so later players know what they must beat).
                         if player.score > score_to_beat:
                             score_to_beat = player.score
-                        
+
                         # whole table has now had exactly one shot
-                        
+
                 if final_round:
                     break
             if final_round:
                 break
-        
-        
+
         sorted_pl = sorted(self.players, key=lambda pl: pl.score, reverse=True)
         winner = sorted_pl[0]
         runner = sorted_pl[1] if len(sorted_pl) > 1 else None
@@ -346,34 +400,34 @@ class FarkleGame:
         players_block: Dict[str, PlayerStats] = {}
         for pl in sorted_pl:
             players_block[pl.name] = PlayerStats(
-                score = pl.score,
-                farkles = pl.n_farkles,
-                rolls = pl.n_rolls,
-                highest_turn = pl.highest_turn,
-                strategy = str(pl.strategy),
-                rank = ranks[pl.name],
-                loss_margin = winner.score - pl.score,
-                smart_five_uses = pl.smart_five_uses,
-                n_smart_five_dice = pl.n_smart_five_dice,
-                smart_one_uses = pl.smart_one_uses,
-                n_smart_one_dice = pl.n_smart_one_dice,
-                hot_dice = pl.n_hot_dice,
+                score=pl.score,
+                farkles=pl.n_farkles,
+                rolls=pl.n_rolls,
+                highest_turn=pl.highest_turn,
+                strategy=str(pl.strategy),
+                rank=ranks[pl.name],
+                loss_margin=winner.score - pl.score,
+                smart_five_uses=pl.smart_five_uses,
+                n_smart_five_dice=pl.n_smart_five_dice,
+                smart_one_uses=pl.smart_one_uses,
+                n_smart_one_dice=pl.n_smart_one_dice,
+                hot_dice=pl.n_hot_dice,
             )
 
         game_block = GameStats(
-            n_players = len(self.players),
-            table_seed = self.table_seed,
-            n_rounds = rounds,
-            total_rolls = sum(pl.n_rolls for pl in self.players),
-            total_farkles = sum(pl.n_farkles for pl in self.players),
-            margin = winner.score - (runner.score if runner else 0),
+            n_players=len(self.players),
+            table_seed=self.table_seed,
+            n_rounds=rounds,
+            total_rolls=sum(pl.n_rolls for pl in self.players),
+            total_farkles=sum(pl.n_farkles for pl in self.players),
+            margin=winner.score - (runner.score if runner else 0),
         )
 
         return GameMetrics(players_block, game_block)
-    
+
         # Legacy metrics engine left here just in case
         # from typing import Any
-        #         
+        #
         # winner = max(self.players, key=lambda pl: pl.score)
         # winner_data: Dict = {
         #     winner.name: {
@@ -383,7 +437,7 @@ class FarkleGame:
         #         "highest_turn": p.highest_turn,
         #         "strategy": str(p.strategy),
         #     }
-        # }    
+        # }
         # per_player: Dict[str, Dict[str, Any]] = {
         #     p.name: {
         #         "score": p.score,


### PR DESCRIPTION
## Summary
- expand `GameStats` docstring with actual fields
- document attributes of `GameMetrics` and `PlayerStats`
- add constructor docstring for `FarkleGame`

## Testing
- `ruff format src/farkle/engine.py`
- `ruff check src/farkle/engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687c50115f20832fafbf2de59046e057