### PR TITLE
Fix style in engine.py

### DIFF
--- a/src/farkle/engine.py
+++ b/src/farkle/engine.py
@@ -49,7 +49,7 @@ class FarklePlayer:
     score: int = 0
     has_scored: bool = False  # entered game (≥500) flag
     rng: np.random.Generator = field(default_factory=np.random.default_rng, repr=False)
-    
+
     # counters
     n_farkles: int = 0
     n_rolls: int = 0
@@ -60,10 +60,10 @@ class FarklePlayer:
     n_smart_one_dice: int = 0
     n_hot_dice: int = 0
     strategy_str: str = field(init=False, repr=False)
-    
+
     def __post_init__(self):
         object.__setattr__(self, "strategy_str", str(self.strategy))
-        
+
     # ----------------------------- helpers -----------------------------
     def _roll(self, n: int) -> DiceRoll:
         """Produce n dice using this player's RNG.
@@ -119,18 +119,18 @@ class FarklePlayer:
             rolls_this_turn += 1
 
             # 2) Compute points from this roll, after applying Smart‐5/Smart‐1 discards
-            pts, used, reroll, d5, d1 = default_score( # type: ignore
-                dice_roll = roll,
-                turn_score_pre = turn_score,
-                smart_five = self.strategy.smart_five,
-                smart_one = self.strategy.smart_one,
-                score_threshold = self.strategy.score_threshold,
-                dice_threshold = self.strategy.dice_threshold,
-                consider_score = self.strategy.consider_score,
-                consider_dice = self.strategy.consider_dice,
-                require_both = self.strategy.require_both,
-                prefer_score = self.strategy.prefer_score,
-                return_discards = True
+            pts, used, reroll, d5, d1 = default_score(  # type: ignore
+                dice_roll=roll,
+                turn_score_pre=turn_score,
+                smart_five=self.strategy.smart_five,
+                smart_one=self.strategy.smart_one,
+                score_threshold=self.strategy.score_threshold,
+                dice_threshold=self.strategy.dice_threshold,
+                consider_score=self.strategy.consider_score,
+                consider_dice=self.strategy.consider_dice,
+                require_both=self.strategy.require_both,
+                prefer_score=self.strategy.prefer_score,
+                return_discards=True,
             )
 
             # 3) If pts == 0, that's a Farkle: bust, lose all points this turn, and end turn
@@ -141,7 +141,7 @@ class FarklePlayer:
 
             # 4) Otherwise, accumulate the points from this roll
             turn_score += pts
-            
+
             # 4.5) Update smart_five and smart_one tracking
             if d5:
                 self.smart_five_uses += 1
@@ -149,17 +149,17 @@ class FarklePlayer:
             if d1:
                 self.smart_one_uses += 1
                 self.n_smart_one_dice += d1
-            
+
             # 5) “Hot dice” logic: if all dice in roll scored (used == len(roll)),
             #    and reroll == 0, that means you get to roll all 6 dice again.
             #    Otherwise, you roll reroll dice next.
             dice = 6 if (used == len(roll) and reroll == 0) else reroll
-            
+
             # 5.5) Hot dice short circuit
             if self.strategy.auto_hot_dice and dice == 6:
                 self.n_hot_dice += 1
                 continue  # force another throw
-            
+
             # 6-A) If we’re in the final round and have already won, stop.
             running_total = self.score + turn_score
             score_needed = max(0, target_score - running_total)
@@ -174,17 +174,18 @@ class FarklePlayer:
             #      - current turn_score
             #      - dice_left = dice (from step 5)
             #      - has_scored = whether we’ve ever scored ≥500 on a previous turn
-            #      - score_needed = how many more points (from banked + turn_score) we need to reach target_score
+            #      - score_needed = how many more points (from banked + turn_score)
+            #                     we need to reach target_score
             keep_rolling = self.strategy.decide(
-                turn_score = turn_score,
-                dice_left = dice,
-                has_scored = self.has_scored,
-                score_needed = score_needed,
-                final_round = final_round,
-                score_to_beat= score_to_beat,
-                running_total= running_total,
+                turn_score=turn_score,
+                dice_left=dice,
+                has_scored=self.has_scored,
+                score_needed=score_needed,
+                final_round=final_round,
+                score_to_beat=score_to_beat,
+                running_total=running_total,
             )
-        
+
             # 6-C) Override the strategy if we’re still behind in the final round.
             if final_round and running_total <= score_to_beat:
                 keep_rolling = True
@@ -192,7 +193,8 @@ class FarklePlayer:
             if not keep_rolling:
                 break
 
-        # 7) After leaving the loop, check if this is our “entry turn” (we need ≥500 to get on the board)
+        # 7) After leaving the loop, check if this is our “entry turn"
+        #     (we need ≥500 to get on the board)
         if not self.has_scored and turn_score >= 500:
             self.has_scored = True
 
@@ -205,6 +207,7 @@ class FarklePlayer:
 # ---------------------------------------------------------------------------
 # Game-level structures
 # ---------------------------------------------------------------------------
+
 
 @dataclass(slots=True)
 class GameStats:
@@ -228,6 +231,7 @@ class GameStats:
     GameMetrics
         New dataclass instance populated with results.
     """
+
     n_players: int
     table_seed: int
     n_rounds: int
@@ -270,8 +274,8 @@ class PlayerStats:
     rolls: int
     highest_turn: int
     strategy: str
-    rank: int # 1 = winner
-    loss_margin: int # 0 for winner, >0 otherwise
+    rank: int  # 1 = winner
+    loss_margin: int  # 0 for winner, >0 otherwise
     smart_five_uses: int = 0
     n_smart_five_dice: int = 0
     smart_one_uses: int = 0
@@ -282,7 +286,13 @@ class PlayerStats:
 class FarkleGame:
     """Driver for a *single* Farkle game."""
 
-    def __init__(self, players: Sequence[FarklePlayer], *, target_score: int = 10_000, table_seed: int = 0) -> None:
+    def __init__(
+        self,
+        players: Sequence[FarklePlayer],
+        *,
+        target_score: int = 10_000,
+        table_seed: int = 0,
+    ) -> None:
         self.players: List[FarklePlayer] = list(players)
         self.target_score: int = target_score
         self.table_seed = table_seed
@@ -308,36 +318,40 @@ class FarkleGame:
             rounds += 1
             for p in self.players:
                 p.take_turn(
-                    self.target_score,  # This is that vestigial stat 
-                    final_round = final_round,
-                    score_to_beat = score_to_beat,
+                    self.target_score,  # This is that vestigial stat
+                    final_round=final_round,
+                    score_to_beat=score_to_beat,
                 )
                 # First trigger starts the final round
                 if not final_round and p.score >= self.target_score:
                     final_round = True
                     score_to_beat = p.score
                     triggering_player = p
-                    final_players = [player for player in self.players if player != triggering_player]
-                
+                    final_players = [
+                        player for player in self.players if player != triggering_player
+                    ]
+
                 if final_round:
-                    for player in final_players:  # All other players have chance to beat the first tentative winner
-                                                  # It's not fair, but it's the rules
-                        player.take_turn(target_score=self.target_score,
-                                         final_round=True,
-                                         score_to_beat=score_to_beat)
-                # During the final round update the bar whenever someone
-                #     jumps ahead (so later players know what they must beat).
+                    # All other players have chance to beat the first tentative
+                    # winner. It's not fair, but it's the rules.
+                    for player in final_players:
+                        player.take_turn(
+                            target_score=self.target_score,
+                            final_round=True,
+                            score_to_beat=score_to_beat,
+                        )
+                        # During the final round update the bar whenever someone
+                        #     jumps ahead (so later players know what they must beat).
                         if player.score > score_to_beat:
                             score_to_beat = player.score
-                        
+
                         # whole table has now had exactly one shot
-                        
+
                 if final_round:
                     break
             if final_round:
                 break
-        
-        
+
         sorted_pl = sorted(self.players, key=lambda pl: pl.score, reverse=True)
         winner = sorted_pl[0]
         runner = sorted_pl[1] if len(sorted_pl) > 1 else None
@@ -346,53 +360,27 @@ class FarkleGame:
         players_block: Dict[str, PlayerStats] = {}
         for pl in sorted_pl:
             players_block[pl.name] = PlayerStats(
-                score = pl.score,
-                farkles = pl.n_farkles,
-                rolls = pl.n_rolls,
-                highest_turn = pl.highest_turn,
-                strategy = str(pl.strategy),
-                rank = ranks[pl.name],
-                loss_margin = winner.score - pl.score,
-                smart_five_uses = pl.smart_five_uses,
-                n_smart_five_dice = pl.n_smart_five_dice,
-                smart_one_uses = pl.smart_one_uses,
-                n_smart_one_dice = pl.n_smart_one_dice,
-                hot_dice = pl.n_hot_dice,
+                score=pl.score,
+                farkles=pl.n_farkles,
+                rolls=pl.n_rolls,
+                highest_turn=pl.highest_turn,
+                strategy=str(pl.strategy),
+                rank=ranks[pl.name],
+                loss_margin=winner.score - pl.score,
+                smart_five_uses=pl.smart_five_uses,
+                n_smart_five_dice=pl.n_smart_five_dice,
+                smart_one_uses=pl.smart_one_uses,
+                n_smart_one_dice=pl.n_smart_one_dice,
+                hot_dice=pl.n_hot_dice,
             )
 
         game_block = GameStats(
-            n_players = len(self.players),
-            table_seed = self.table_seed,
-            n_rounds = rounds,
-            total_rolls = sum(pl.n_rolls for pl in self.players),
-            total_farkles = sum(pl.n_farkles for pl in self.players),
-            margin = winner.score - (runner.score if runner else 0),
+            n_players=len(self.players),
+            table_seed=self.table_seed,
+            n_rounds=rounds,
+            total_rolls=sum(pl.n_rolls for pl in self.players),
+            total_farkles=sum(pl.n_farkles for pl in self.players),
+            margin=winner.score - (runner.score if runner else 0),
         )
 
         return GameMetrics(players_block, game_block)
-    
-        # Legacy metrics engine left here just in case
-        # from typing import Any
-        #         
-        # winner = max(self.players, key=lambda pl: pl.score)
-        # winner_data: Dict = {
-        #     winner.name: {
-        #         "score": p.score,
-        #         "farkles": p.n_farkles,
-        #         "rolls": p.n_rolls,
-        #         "highest_turn": p.highest_turn,
-        #         "strategy": str(p.strategy),
-        #     }
-        # }    
-        # per_player: Dict[str, Dict[str, Any]] = {
-        #     p.name: {
-        #         "score": p.score,
-        #         "farkles": p.n_farkles,
-        #         "rolls": p.n_rolls,
-        #         "highest_turn": p.highest_turn,
-        #         "strategy": str(p.strategy),
-        #     }
-        #     for p in self.players
-        # }
-        #
-        # return GameMetrics(winner.name, winner.score, rounds, per_player, winner_data)


### PR DESCRIPTION
## Summary
- wrap long lines in engine.py
- remove trailing spaces
- drop obsolete legacy metrics code

## Testing
- `ruff check src/farkle/engine.py`
- `black src/farkle/engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c50154b98832fba20f16f187aace7