### PR TITLE
Add CLI module docstring

### DIFF
--- a/src/farkle/farkle_cli.py
+++ b/src/farkle/farkle_cli.py
@@ -1,4 +1,11 @@
 # src/farkle/cli.py
+"""CLI entry point for the Farkle package.
+
+This module exposes the command line interface.  At present the only
+available subcommand is ``run``.  It reads a YAML configuration file and
+invokes :func:`simulate_many_games_stream` to execute simulations.
+"""
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary
- document the CLI entry point

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c5048203c832fb4d928c8e3163f20