### PR TITLE
Add CLI validation tests

### DIFF
--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -75,3 +75,26 @@ def test_stream_parallel(tmp_path, n_jobs):
     )
     rows = out.read_text().splitlines()
     assert len(rows) == 5  # header + 4
+
+
+def test_cli_missing_file(monkeypatch):
+    bad = "nope.yml"
+    monkeypatch.setattr(sys, "argv", ["farkle", "run", bad])
+    with pytest.raises(FileNotFoundError):
+        farkle_cli.main()
+
+
+def test_cli_bad_yaml(tmp_path, monkeypatch):
+    cfg = tmp_path / "bad.yml"
+    cfg.write_text("{:")  # invalid YAML
+    monkeypatch.setattr(sys, "argv", ["farkle", "run", str(cfg)])
+    with pytest.raises(yaml.YAMLError):
+        farkle_cli.main()
+
+
+def test_cli_missing_keys(tmp_path, monkeypatch):
+    cfg = tmp_path / "missing.yml"
+    cfg.write_text(yaml.safe_dump({}))
+    monkeypatch.setattr(sys, "argv", ["farkle", "run", str(cfg)])
+    with pytest.raises(KeyError):
+        farkle_cli.main()


### PR DESCRIPTION
## Summary
- cover CLI error cases in unit tests

## Testing
- `pytest tests/unit/test_utilities.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c5050e184832faf1d9f7b2e7ee1af