### PR TITLE
Ensure directories exist when streaming results

### DIFF
--- a/src/farkle/farkle_io.py
+++ b/src/farkle/farkle_io.py
@@ -75,7 +75,10 @@ def simulate_many_games_stream(
 
     # We will write only five tiny columns per game
     header = ["game_id", "winner", "winning_score", "winner_strategy", "n_rounds"]
-    
+
+    # ensure target directory exists
+    Path(out_csv).parent.mkdir(parents=True, exist_ok=True)
+
     # --- truncate file & write header once, upfront --------------------
     with open(out_csv, "w", newline="") as fh:
         writer = csv.DictWriter(fh, fieldnames=header)

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -75,3 +75,16 @@ def test_stream_parallel(tmp_path, n_jobs):
     )
     rows = out.read_text().splitlines()
     assert len(rows) == 5  # header + 4
+
+
+def test_stream_nested_output(tmp_path):
+    out = tmp_path / "subdir" / "out.csv"
+    strategies = [ThresholdStrategy(score_threshold=0, dice_threshold=6)]
+    simulate_many_games_stream(
+        n_games=2,
+        strategies=strategies,
+        out_csv=str(out),
+        seed=42,
+        n_jobs=1,
+    )
+    assert out.exists()


### PR DESCRIPTION
## Summary
- create the parent folder for `simulate_many_games_stream` output
- test streaming to a nested directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c505eab60832f905e19e42a84cb1f