### PR TITLE
Fix trailing whitespace

### DIFF
--- a/src/farkle/farkle_io.py
+++ b/src/farkle/farkle_io.py
@@ -57,7 +57,7 @@ def simulate_many_games_stream(
 
     Each finished game immediately lands as one row in *out_csv*:
         game_id, winner, winning_score, winner_strategy, n_rounds
-    
+
     Inputs:
         n_games: Number of games to simulate.
         strategies: Strategies to assign to the players.
@@ -75,12 +75,12 @@ def simulate_many_games_stream(
 
     # We will write only five tiny columns per game
     header = ["game_id", "winner", "winning_score", "winner_strategy", "n_rounds"]
-    
+
     # --- truncate file & write header once, upfront --------------------
     with open(out_csv, "w", newline="") as fh:
         writer = csv.DictWriter(fh, fieldnames=header)
         writer.writeheader()
-        
+
     if n_jobs == 1:
         with open(out_csv, "w", newline="") as fh:
             writer = csv.DictWriter(fh, fieldnames=header)


### PR DESCRIPTION
## Summary
- remove trailing spaces from Farkle IO module

## Testing
- `ruff check .` *(fails: found 182 errors)*
- `black --check .` *(fails: would reformat 33 files)*

------
https://chatgpt.com/codex/tasks/task_e_687c5061d880832f8304b290e4b25a93