### PR TITLE
Add seed-based simulation helper

### DIFF
--- a/src/farkle/run_bonferroni_head2head.py
+++ b/src/farkle/run_bonferroni_head2head.py
@@ -8,7 +8,7 @@ from typing import List
 import pandas as pd
 from scipy.stats import binomtest
 
-from .simulation import simulate_many_games
+from .simulation import simulate_many_games_from_seeds
 from .stats import games_for_power
 from .strategies import parse_strategy
 from .utils import bonferroni_pairs
@@ -24,13 +24,11 @@ def run_bonferroni_head2head(seed: int = 0) -> None:
 
     records = []
     for (a, b), grp in schedule.groupby(["a", "b"]):
-        n_games = len(grp)
-        df = simulate_many_games(
-            n_games=n_games, 
-            strategies=[parse_strategy(a), parse_strategy(b)], 
-            seed=seed, 
-            n_jobs=1
-            )
+        df = simulate_many_games_from_seeds(
+            seeds=grp["seed"].tolist(),
+            strategies=[parse_strategy(a), parse_strategy(b)],
+            n_jobs=1,
+        )
         wins = df["winner_strategy"].value_counts()
         wa = int(wins.get(a, 0))
         wb = int(wins.get(b, 0))

--- a/src/farkle/simulation.py
+++ b/src/farkle/simulation.py
@@ -28,6 +28,7 @@ __all__: list[str] = [
     "experiment_size",
     "simulate_one_game",
     "simulate_many_games",
+    "simulate_many_games_from_seeds",
     "aggregate_metrics",
 ]
 
@@ -214,6 +215,23 @@ def simulate_many_games(
     
     master_rng = np.random.default_rng(seed)
     seeds = master_rng.integers(0, 2**32 - 1, size=n_games).tolist()
+    args = [(s, strategies, target_score) for s in seeds]
+    if n_jobs == 1:
+        rows = [_play_game(*a) for a in args]
+    else:
+        with mp.Pool(processes=n_jobs) as pool:
+            rows = pool.starmap(_play_game, args)
+    return pd.DataFrame(rows)
+
+
+def simulate_many_games_from_seeds(
+    seeds: Sequence[int],
+    strategies: Sequence[ThresholdStrategy],
+    target_score: int = 10_000,
+    n_jobs: int = 1,
+) -> pd.DataFrame:
+    """Run games using the provided sequence of seeds."""
+
     args = [(s, strategies, target_score) for s in seeds]
     if n_jobs == 1:
         rows = [_play_game(*a) for a in args]

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pandas as pd
 from pandas import DataFrame
 
 from farkle.simulation import (
@@ -5,6 +7,7 @@ from farkle.simulation import (
     experiment_size,
     generate_strategy_grid,
     simulate_many_games,
+    simulate_many_games_from_seeds,
     simulate_one_game,
 )
 from farkle.strategies import ThresholdStrategy
@@ -49,4 +52,15 @@ def test_custom_grid_size():
     strategies, meta = generate_strategy_grid(auto_hot_opts=[True])
     assert len(strategies) == 4080
     assert len(meta) == 4080
+
+
+def test_simulate_many_games_from_seeds_matches():
+    strats = [ThresholdStrategy(score_threshold=100, dice_threshold=0)]
+    rng_seed = 42
+    n_games = 5
+    rng = np.random.default_rng(rng_seed)
+    seeds = rng.integers(0, 2**32 - 1, size=n_games).tolist()
+    df1 = simulate_many_games_from_seeds(seeds=seeds, strategies=strats, n_jobs=1)
+    df2 = simulate_many_games(n_games=n_games, strategies=strats, seed=rng_seed, n_jobs=1)
+    pd.testing.assert_frame_equal(df1, df2)
     


### PR DESCRIPTION
## Summary
- add `simulate_many_games_from_seeds` to play games using fixed seeds
- update Bonferroni head-to-head to consume scheduled seeds
- test new helper and verify deterministic results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c50801d4c832f8f6acee5f0dbfc46