### PR TITLE
Improve tier loading error handling

### DIFF
--- a/src/farkle/run_bonferroni_head2head.py
+++ b/src/farkle/run_bonferroni_head2head.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from typing import List
 
+TIERS_PATH = Path("data/tiers.json")
+
 import pandas as pd
 from scipy.stats import binomtest
 
@@ -15,8 +17,13 @@ from .utils import bonferroni_pairs
 
 
 def run_bonferroni_head2head(seed: int = 0) -> None:
-    with open("data/tiers.json") as fh:
-        tiers = json.load(fh)
+    try:
+        with TIERS_PATH.open() as fh:
+            tiers = json.load(fh)
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Tier file not found at {TIERS_PATH}") from exc
+    if not tiers:
+        raise RuntimeError(f"No tiers found in {TIERS_PATH}")
     top_val = min(tiers.values())
     elites = [s for s, t in tiers.items() if t == top_val]
     games_needed = games_for_power(len(elites), method="bonferroni", pairwise=True)


### PR DESCRIPTION
## Summary
- handle missing tiers.json gracefully
- add check for empty tiers file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c508e6638832fac6c17a3eec39d12