### PR TITLE
Add num_shuffles parameter to tournament

### DIFF
--- a/src/farkle/run_full_field.py
+++ b/src/farkle/run_full_field.py
@@ -6,7 +6,6 @@ run_full_field.py  -  Phase-1 full-grid screen for all table sizes
    • Detectable lift Δ   = 0.03     (3-percentage-point edge)
 """
 
-import importlib
 import multiprocessing as mp
 import shutil
 from math import ceil
@@ -17,21 +16,21 @@ import pandas as pd
 from scipy.stats import norm
 
 # Seed 1 Global Config
-    # # ────────── GLOBAL CONFIG ─────────────────────────────────────────
-    # PLAYERS = [2, 3, 4, 5, 6, 8, 10, 12]
-    # GRID = 8_160  # total strategies
-    # DELTA = 0.03  # abs lift to detect
-    # POWER = 0.95  # 1 – β
-    # Q_FDR = 0.02  # BH, two-sided
-    # GLOBAL_SEED = 42
-    # JOBS = None  # None → all logical cores
-    # BASE_OUT = Path("data/results_seed_42")
-    # BASE_OUT.mkdir(parents=True, exist_ok=True)
-    # # ------------------------------------------------------------------
+# # ────────── GLOBAL CONFIG ─────────────────────────────────────────
+# PLAYERS = [2, 3, 4, 5, 6, 8, 10, 12]
+# GRID = 8_160  # total strategies
+# DELTA = 0.03  # abs lift to detect
+# POWER = 0.95  # 1 – β
+# Q_FDR = 0.02  # BH, two-sided
+# GLOBAL_SEED = 42
+# JOBS = None  # None → all logical cores
+# BASE_OUT = Path("data/results_seed_42")
+# BASE_OUT.mkdir(parents=True, exist_ok=True)
+# # ------------------------------------------------------------------
 
-    # # pre-compute critical z-scores
-    # Z_ALPHA = norm.isf(Q_FDR / 2)  # two-sided BH
-    # Z_BETA = norm.isf(1 - POWER)  # power target
+# # pre-compute critical z-scores
+# Z_ALPHA = norm.isf(Q_FDR / 2)  # two-sided BH
+# Z_BETA = norm.isf(1 - POWER)  # power target
 
 
 def _concat_row_shards(out_dir: Path, n: int) -> None:
@@ -47,7 +46,7 @@ def _concat_row_shards(out_dir: Path, n: int) -> None:
 
 def main():
     import farkle.run_tournament as rt  # required for main hook  # noqa: I001
-    
+
     # ────────── GLOBAL CONFIG ─────────────────────────────────────────
     PLAYERS = [2, 3, 4, 5, 6, 8, 10, 12]
     GRID = 8_160  # total strategies
@@ -68,7 +67,7 @@ def main():
         """Return observations/strategy (≡ shuffles) for given table size."""
         p0 = 1 / n_players
         var = p0 * (1 - p0) + (p0 + DELTA) * (1 - p0 - DELTA)
-        n = ((Z_ALPHA + Z_BETA) ** 2 * var) / (DELTA ** 2)
+        n = ((Z_ALPHA + Z_BETA) ** 2 * var) / (DELTA**2)
         return ceil(n)
 
     mp.set_start_method("spawn", force=True)
@@ -87,24 +86,22 @@ def main():
             flush=True,
         )
 
-        # fresh module copy for clean monkey-patch
-        rt = importlib.reload(rt)
-        rt.NUM_SHUFFLES = nshuf  # type: ignore
-
         t0 = perf_counter()
         rt.run_tournament(
-            n_players = n,
+            n_players=n,
             global_seed=GLOBAL_SEED,
             checkpoint_path=out_dir / f"{n}p_checkpoint.pkl",
             n_jobs=JOBS,
             collect_metrics=True,
             row_output_directory=out_dir / f"{n}p_rows",
+            num_shuffles=nshuf,
         )
         dt = perf_counter() - t0
         print(f"✅ finished {n}-player in {dt/60:5.1f} min\n", flush=True)
         _concat_row_shards(out_dir, n)
     print("🏁  All table sizes completed.")
 
-if __name__=='__main__':
+
+if __name__ == "__main__":
     # run: python -m farkle.run_full_field
     main()

--- a/tests/integration/test_run_tournament_integration.py
+++ b/tests/integration/test_run_tournament_integration.py
@@ -83,7 +83,6 @@ def _init_worker_small(
 
     # Drastically cut the workload
     _rt.GAMES_PER_SHUFFLE = 2  # type: ignore
-    _rt.NUM_SHUFFLES = 2  # type: ignore
     _rt.DESIRED_SEC_PER_CHUNK = 0.1  # type: ignore
     _rt.CKPT_EVERY_SEC = 1  # type: ignore
 
@@ -109,7 +108,6 @@ def _apply_fast_patches(monkeypatch: pytest.MonkeyPatch, rt) -> None:  # type: i
     _tiny_grid = _tiny_strategy_grid()
 
     # 3a. Constants in parent (affects chunking logic)
-    monkeypatch.setattr(rt, "NUM_SHUFFLES", 2, raising=False)
     monkeypatch.setattr(rt, "GAMES_PER_SHUFFLE", 2, raising=False)
     monkeypatch.setattr(rt, "DESIRED_SEC_PER_CHUNK", 0.1, raising=False)
     monkeypatch.setattr(rt, "CKPT_EVERY_SEC", 1, raising=False)
@@ -140,6 +138,7 @@ def test_run_tournament_process_pool(monkeypatch: pytest.MonkeyPatch, tmp_path: 
         "global_seed": 123,
         "checkpoint_path": ckpt,
         "n_jobs": 2,
+        "num_shuffles": 2,
     }
     if "n_players" in inspect.signature(rt.run_tournament).parameters:
         kwargs["n_players"] = rt.N_PLAYERS
@@ -181,6 +180,8 @@ def test_run_tournament_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         "2",
         "--ckpt-sec",
         "1",
+        "--num-shuffles",
+        "2",
     ]
     if "--players" in inspect.getsource(rt.main):
         argv.extend(["--n_players", str(rt.N_PLAYERS)])

--- a/tests/unit/test_run_full_field.py
+++ b/tests/unit/test_run_full_field.py
@@ -27,16 +27,16 @@ def test_main_invokes_run_tournament(monkeypatch: MonkeyPatch, tmp_path: rf.Path
     calls = []
 
     def fake_run_tournament(**kwargs):
-        calls.append(kwargs["row_output_directory"])
+        calls.append((kwargs["row_output_directory"], kwargs.get("num_shuffles")))
 
     monkeypatch.setattr("farkle.run_tournament.run_tournament", fake_run_tournament)
-    monkeypatch.setattr(rf.importlib, "reload", lambda mod: mod)
     monkeypatch.setattr(rf.mp, "set_start_method", lambda *a, **k: None)  # noqa: ARG005
     monkeypatch.chdir(tmp_path)
 
     rf.main()
 
     players = [2, 3, 4, 5, 6, 8, 10, 12]
-    seen = sorted(int(p.parent.name.split("_")[0]) for p in calls)
+    seen = sorted(int(p[0].parent.name.split("_")[0]) for p in calls)
     assert seen == players
     assert len(calls) == len(players)
+    assert all(isinstance(nshuf, int) for _, nshuf in calls)

--- a/tests/unit/test_run_tournament.py
+++ b/tests/unit/test_run_tournament.py
@@ -23,10 +23,7 @@ from farkle.strategies import ThresholdStrategy
 
 def _mini_strats(n: int = 6):
     """Return deterministic Strategy objects with distinct __str__()."""
-    return [
-        ThresholdStrategy(50 + 50 * i, i % 3, True, True)
-        for i in range(n)
-    ]
+    return [ThresholdStrategy(50 + 50 * i, i % 3, True, True) for i in range(n)]
 
 
 @pytest.fixture(autouse=True)
@@ -37,8 +34,9 @@ def fast_helpers(monkeypatch):
     3) Skip the ProcessPool - we call _run_chunk() directly.
     """
     strats = _mini_strats(12)
-    monkeypatch.setattr(rt, "generate_strategy_grid",
-                        lambda *a, **kw: (strats, None), raising=True)  # noqa: ARG005
+    monkeypatch.setattr(
+        rt, "generate_strategy_grid", lambda *a, **kw: (strats, None), raising=True
+    )  # noqa: ARG005
 
     def fake_play_shuffle(seed: int) -> Counter[str]:
         # pretend player at index (seed % len(strats)) always wins
@@ -63,35 +61,39 @@ def test_checkpoint_timer(monkeypatch, tmp_path):
     """
 
     # ── 1 · deterministic, instantly-returning ProcessPool substitute ─────────
-    
+
     class DummyFuture:
         def __init__(self, result):
             self._result = result
+
         def result(self):  # mimic concurrent.futures.Future
             return self._result
+
         def __hash__(self):  # make it usable as a dict key
             return id(self)
+
         def __eq__(self, other):
             return self is other
 
     class DummyPool:
-        def __enter__(self): return self
-        def __exit__(self, *a): return False
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
         def submit(self, fn, arg):
             # run the work *eagerly* and wrap the result
             return DummyFuture(fn(arg))
 
-    monkeypatch.setattr(rt, "ProcessPoolExecutor",
-                        lambda *a, **k: DummyPool())  # noqa: ARG005
+    monkeypatch.setattr(rt, "ProcessPoolExecutor", lambda *a, **k: DummyPool())  # noqa: ARG005
 
-    # ── 2 · speed-up constants so only TWO chunks total ───────────────────────
-    monkeypatch.setattr(rt, "NUM_SHUFFLES", 2, raising=False)
-
-    # ── 3 · fake wall-clock (t jumps +31 s before the 2nd chunk) ─────────────
+    # ── 2 · fake wall-clock (t jumps +31 s before the 2nd chunk) ─────────────
     t = 0.0
-    
+
     def fake_perf():  # our replacement for time.perf_counter()
         return t
+
     monkeypatch.setattr(rt.time, "perf_counter", fake_perf, raising=True)
 
     def fake_as_completed(dct):  # yield first future, then advance time
@@ -102,27 +104,35 @@ def test_checkpoint_timer(monkeypatch, tmp_path):
         t += 31  # 31 s later → timer should fire
         for fut in it:
             yield fut
+
     monkeypatch.setattr(rt, "as_completed", fake_as_completed, raising=True)
 
-    # ── 4 · skip the real throughput probe (no timing, no games) ──────────────
-    monkeypatch.setattr(rt, "_measure_throughput",
-                        lambda *a, **k: 1,  # small → 1 shuffle / chunk  # noqa: ARG005
-                        raising=True)
+    # ── 3 · skip the real throughput probe (no timing, no games) ──────────────
+    monkeypatch.setattr(
+        rt,
+        "_measure_throughput",
+        lambda *a, **k: 1,  # small → 1 shuffle / chunk  # noqa: ARG005
+        raising=True,
+    )
 
-    # ── 5 · count how many times we attempt to write a checkpoint ─────────────
+    # ── 4 · count how many times we attempt to write a checkpoint ─────────────
     saves = {"n": 0}
-    
+
     def fake_write_bytes(self, data):  # noqa: ARG001
         saves["n"] += 1
+
     monkeypatch.setattr(rt.Path, "write_bytes", fake_write_bytes, raising=True)
 
     # also silence logging noise
     monkeypatch.setattr(rt.logging, "info", lambda *a, **k: None, raising=False)  # noqa: ARG005
 
-    # ── 6 · run – we expect 1 mid-run save + 1 final save ─────────────────────
-    rt.run_tournament(global_seed=0,
-                      checkpoint_path=tmp_path / "chk.pkl",
-                      n_jobs=None,
-                      ckpt_every_sec=30)
+    # ── 5 · run – we expect 1 mid-run save + 1 final save ─────────────────────
+    rt.run_tournament(
+        global_seed=0,
+        checkpoint_path=tmp_path / "chk.pkl",
+        n_jobs=None,
+        ckpt_every_sec=30,
+        num_shuffles=2,
+    )
 
     assert saves["n"] == 2  # exactly one inside the loop, one at end


### PR DESCRIPTION
## Summary
- support `num_shuffles` parameter in `run_tournament`
- expose `--num-shuffles` CLI option
- update `run_full_field` to pass the new argument and drop reloading
- adjust unit and integration tests for the API change

## Testing
- `pytest tests/unit/test_run_tournament.py::test_checkpoint_timer -q`
- `pytest tests/unit/test_run_full_field.py::test_main_invokes_run_tournament -q`
- `pytest tests/integration/test_run_tournament_integration.py::test_run_tournament_process_pool -q`
- `pytest tests/integration/test_run_tournament_integration.py::test_run_tournament_cli -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c50bf6e0c832faaf45124af47e693