### PR TITLE
Add partial dependence plotting helper

### DIFF
--- a/tests/unit/test_run_rf_helpers.py
+++ b/tests/unit/test_run_rf_helpers.py
@@ -1,0 +1,14 @@
+import pandas as pd
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+from farkle.run_rf import plot_partial_dependence
+
+
+def test_plot_partial_dependence(tmp_path):
+    X = pd.DataFrame({"a": range(5), "b": range(5, 10)})
+    y = pd.Series(range(5))
+    model = HistGradientBoostingRegressor(random_state=0)
+    model.fit(X, y)
+
+    out_file = plot_partial_dependence(model, X, "a", tmp_path)
+    assert out_file.exists()


### PR DESCRIPTION
## Summary
- add a function to plot partial dependence and save the output
- use the helper in `run_rf`
- test plotting helper with synthetic data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c50d9766c832f968fe05904342128