### PR TITLE
Add output argument to run_rf

### DIFF
--- a/src/farkle/run_rf.py
+++ b/src/farkle/run_rf.py
@@ -7,13 +7,15 @@ import warnings
 from pathlib import Path
 from typing import List
 
+IMPORTANCE_PATH = Path("data/rf_importance.json")
+
 import matplotlib.pyplot as plt
 import pandas as pd
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.inspection import PartialDependenceDisplay, permutation_importance
 
 
-def run_rf(seed: int = 0) -> None:
+def run_rf(seed: int = 0, output_path: Path = IMPORTANCE_PATH) -> None:
     metrics = pd.read_parquet("data/metrics.parquet")
     with open("data/ratings_pooled.pkl", "rb") as fh:
         ratings = pickle.load(fh)
@@ -28,8 +30,8 @@ def run_rf(seed: int = 0) -> None:
 
     imp = permutation_importance(model, X, y, n_repeats=5, random_state=seed)
     imp_dict = {c: float(s) for c, s in zip(X.columns, imp["importances_mean"], strict=False)}
-    Path("data").mkdir(exist_ok=True)
-    with (Path("data") / "rf_importance.json").open("w") as fh:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w") as fh:
         json.dump(imp_dict, fh, indent=2, sort_keys=True)
 
     figs = Path("notebooks/figs")
@@ -46,10 +48,23 @@ def run_rf(seed: int = 0) -> None:
 
 
 def main(argv: List[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Random forest analysis")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Train a random forest using data/metrics.parquet and data/ratings_pooled.pkl. "
+            "Run from the project root. Writes rf_importance.json to --output and partial "
+            "dependence plots to notebooks/figs/."
+        )
+    )
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=IMPORTANCE_PATH,
+        help="Path to write rf_importance.json",
+    )
     args = parser.parse_args(argv or [])
-    run_rf(seed=args.seed)
+    run_rf(seed=args.seed, output_path=args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow a configurable output path for `run_rf`
- document working directory and output files in the CLI help

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c50daa560832f8be2b8757643e9ab