### PR TITLE
Restrict row logging exception handling

### DIFF
--- a/src/farkle/run_tournament.py
+++ b/src/farkle/run_tournament.py
@@ -196,12 +196,12 @@ def _run_chunk_metrics(
         try:
             import pyarrow as pa
             import pyarrow.parquet as pq
-
+        except ImportError:  # pragma: no cover - optional dependency
+            logging.warning("pyarrow not installed - row logging skipped")
+        else:
             assert row_dir is not None
             out = row_dir / f"rows_{mp.current_process().pid}_{time.time_ns()}.parquet"
             pq.write_table(pa.Table.from_pylist(all_rows), out)
-        except Exception:  # pragma: no cover - optional dependency
-            logging.warning("pyarrow not installed - row logging skipped")
 
     return wins_total, sums_total, sq_total
 

--- a/tests/unit/test_run_tournament_metrics.py
+++ b/tests/unit/test_run_tournament_metrics.py
@@ -76,6 +76,26 @@ def test_run_chunk_metrics_row_logging(monkeypatch, tmp_path):
     assert written["tbl"] == "tbl"
     assert written["path"].parent == tmp_path
     assert written["path"].name == "rows_42_99.parquet"
+
+
+def test_run_chunk_metrics_skips_on_missing_pyarrow(monkeypatch, tmp_path):
+    monkeypatch.setattr(rt, "_play_one_shuffle", _fake_play_one_shuffle, raising=True)
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("pyarrow"):
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    wins, sums, sqs = rt._run_chunk_metrics([4], collect_rows=True, row_dir=tmp_path)
+
+    assert wins == Counter({"S4": 1})
+    assert list(tmp_path.iterdir()) == []
     
 def test_save_checkpoint_round_trip(tmp_path):
     wins = Counter({"A": 2})


### PR DESCRIPTION
## Summary
- restrict `_run_chunk_metrics` to catch only `ImportError` while logging rows
- add a unit test covering missing `pyarrow`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c50fa0b90832f91034f7cc469c3cf