### PR TITLE
Enforce player divisibility rule

### DIFF
--- a/src/farkle/run_tournament.py
+++ b/src/farkle/run_tournament.py
@@ -62,6 +62,8 @@ def _init_worker(
     """Run once in every worker; copy strats **and** table size."""
 
     global _STRATS, N_PLAYERS, GAMES_PER_SHUFFLE
+    if 8_160 % n_players != 0:
+        raise ValueError("n_players must divide 8,160")
     _STRATS = list(strategies)
     N_PLAYERS = n_players
     GAMES_PER_SHUFFLE = 8_160 // N_PLAYERS
@@ -259,10 +261,12 @@ def run_tournament(
     """Orchestrate the multi-process tournament."""
         
     strategies, _ = generate_strategy_grid()  # 8 160 strategies
-    
+
     global N_PLAYERS, GAMES_PER_SHUFFLE
     if n_players < 2:
         raise ValueError("n_players must be ≥2")
+    if 8_160 % n_players != 0:
+        raise ValueError("n_players must divide 8,160")
     N_PLAYERS = n_players
     GAMES_PER_SHUFFLE = 8_160 // N_PLAYERS
     

--- a/tests/unit/test_run_tournament.py
+++ b/tests/unit/test_run_tournament.py
@@ -126,3 +126,43 @@ def test_checkpoint_timer(monkeypatch, tmp_path):
                       ckpt_every_sec=30)
 
     assert saves["n"] == 2  # exactly one inside the loop, one at end
+
+
+def test_init_worker_valid_and_invalid(monkeypatch):
+    strats = _mini_strats(8)
+    rt._init_worker(strats, 4)
+    assert rt.N_PLAYERS == 4
+    assert rt.GAMES_PER_SHUFFLE == 8_160 // 4
+
+    with pytest.raises(ValueError):
+        rt._init_worker(strats, 7)
+
+    rt._init_worker(strats, 5)
+
+
+def test_run_tournament_player_count(monkeypatch, tmp_path):
+    class DummyFuture:
+        def __init__(self, result):
+            self._result = result
+        def result(self):
+            return self._result
+
+    class DummyPool:
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def submit(self, fn, arg):
+            return DummyFuture(fn(arg))
+
+    monkeypatch.setattr(rt, "ProcessPoolExecutor", lambda *a, **k: DummyPool())
+    monkeypatch.setattr(rt, "_measure_throughput", lambda *a, **k: 1, raising=True)
+    monkeypatch.setattr(rt, "NUM_SHUFFLES", 1, raising=False)
+    monkeypatch.setattr(rt.Path, "write_bytes", lambda *a, **k: None, raising=True)
+    monkeypatch.setattr(rt.logging, "info", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(rt, "as_completed", lambda d: list(d.keys()), raising=True)
+
+    rt.run_tournament(n_players=6, checkpoint_path=tmp_path / "c.pkl", n_jobs=None)
+
+    with pytest.raises(ValueError):
+        rt.run_tournament(n_players=7, checkpoint_path=tmp_path / "d.pkl", n_jobs=None)


### PR DESCRIPTION
## Summary
- validate that the number of players divides 8160
- test `run_tournament` and `_init_worker` for valid/invalid player counts

## Testing
- `pytest tests/unit/test_run_tournament.py::test_init_worker_valid_and_invalid -q`
- `pytest tests/unit/test_run_tournament.py::test_run_tournament_player_count -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c50fa2a68832fa551f2d241b771bb