### PR TITLE
Refactor tournament futures loop

### DIFF
--- a/src/farkle/run_tournament.py
+++ b/src/farkle/run_tournament.py
@@ -304,9 +304,9 @@ def run_tournament(
     with ProcessPoolExecutor(
         max_workers=n_jobs, initializer=_init_worker, initargs=(strategies, N_PLAYERS)
     ) as pool:
-        future_to_index = {pool.submit(chunk_fn, c): i for i, c in enumerate(chunks)}
+        futures = [pool.submit(chunk_fn, c) for c in chunks]
 
-        for done, fut in enumerate(as_completed(future_to_index), 1):
+        for done, fut in enumerate(as_completed(futures), 1):
             result = fut.result()
             if collect_metrics or collect_rows:
                 wins, sums, sqs = cast(

--- a/tests/unit/test_run_tournament.py
+++ b/tests/unit/test_run_tournament.py
@@ -94,9 +94,9 @@ def test_checkpoint_timer(monkeypatch, tmp_path):
         return t
     monkeypatch.setattr(rt.time, "perf_counter", fake_perf, raising=True)
 
-    def fake_as_completed(dct):  # yield first future, then advance time
+    def fake_as_completed(futures):  # yield first future, then advance time
         nonlocal t
-        it = iter(dct.keys())
+        it = iter(futures)
         fut1 = next(it)
         yield fut1  # after first chunk (t = 0)
         t += 31  # 31 s later → timer should fire


### PR DESCRIPTION
## Summary
- simplify future submission loop in `run_tournament`
- adjust unit test for new `as_completed` behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c50fb067c832fa7a3fd5b80ff53cb