### PR TITLE
Handle multiple game shards for TrueSkill

### DIFF
--- a/src/farkle/run_trueskill.py
+++ b/src/farkle/run_trueskill.py
@@ -35,10 +35,12 @@ def _load_ranked_games(block: Path) -> list[list[str]]:
         3. <block>/*.parquet                # legacy parquet(s) in root
     """
     # ── 1. Modern layout ────────────────────────────────────────────────────
-    row_dir = next(block.glob("*_rows"), None)
-    if row_dir:
-        frames = [pd.read_parquet(p) for p in row_dir.glob("*.parquet")]
-        df = pd.concat(frames, ignore_index=True)
+    row_dirs = sorted(block.glob("*_rows"))
+    if row_dirs:
+        frames: list[pd.DataFrame] = []
+        for row_dir in row_dirs:
+            frames.extend(pd.read_parquet(p) for p in row_dir.glob("*.parquet"))
+        df = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
 
     # ── 2. winners.csv fallback ────────────────────────────────────────────
     elif (block / "winners.csv").exists():

--- a/tests/unit/test_run_trueskill_helpers.py
+++ b/tests/unit/test_run_trueskill_helpers.py
@@ -47,6 +47,19 @@ def test_load_ranked_games_csv(tmp_path):
     assert games == [["X"], ["Y"]]  # list-of-lists
 
 
+def test_load_ranked_games_multi_row_dirs(tmp_path):
+    block   = tmp_path / "m_players"
+    row1    = block / "1_rows"
+    row2    = block / "2_rows"
+    row1.mkdir(parents=True)
+    row2.mkdir()
+    pd.DataFrame({"winner_strategy": ["A"]}).to_parquet(row1 / "a.parquet")
+    pd.DataFrame({"winner_strategy": ["B"]}).to_parquet(row2 / "b.parquet")
+
+    games = rt._load_ranked_games(block)
+    assert sorted(games) == [["A"], ["B"]]
+
+
 def test_update_ratings_ranked():
     env = trueskill.TrueSkill()
 


### PR DESCRIPTION
## Summary
- improve `_load_ranked_games` to read every `*_rows` dir
- include new unit test covering multiple `_rows` directories

## Testing
- `pytest tests/unit/test_run_trueskill_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c6456f238832fbf6b995af9003223