### PR TITLE
Rename seed flag for TrueSkill CLI

### DIFF
--- a/src/farkle/run_trueskill.py
+++ b/src/farkle/run_trueskill.py
@@ -51,24 +51,24 @@ def _load_ranked_games(block: Path) -> list[list[str]]:
             frames = [pd.read_parquet(p) for p in parquet_files]
             df = pd.concat(frames, ignore_index=True)
         else:
-            return []                       # nothing we know how to read
+            return []  # nothing we know how to read
 
     # ----------------------------------------------------------------------
-    rank_cols  = [c for c in df.columns if c.endswith("_rank")]
+    rank_cols = [c for c in df.columns if c.endswith("_rank")]
     strat_cols = {c[:-5]: f"{c[:-5]}_strategy" for c in rank_cols}
 
     games: list[list[str]] = []
     for _, row in df.iterrows():
-        if rank_cols:                                   # modern per-player ranks
+        if rank_cols:  # modern per-player ranks
             ordered = sorted(rank_cols, key=row.__getitem__)
             players = [row[strat_cols[c[:-5]]] for c in ordered]
-        else:                                           # winner-only rows
+        else:  # winner-only rows
             if "winner_strategy" in row:
                 players = [row["winner_strategy"]]
             elif "winner" in row:
                 players = [row["winner"]]
             else:
-                players = []        # unknown schema → ignore row
+                players = []  # unknown schema → ignore row
         games.append(players)
 
     return games
@@ -82,14 +82,12 @@ def _update_ratings(
     """
     Update ratings using TrueSkill's team API with full table rankings.
     """
-    ratings: dict[str, trueskill.Rating] = {
-        k: env.create_rating() for k in keepers
-    }
+    ratings: dict[str, trueskill.Rating] = {k: env.create_rating() for k in keepers}
 
     for game in games:
         # keep only the strategies we really want to rate
         players = [s for s in game if (not keepers or s in keepers)]
-        teams   = [[ratings.setdefault(s, env.create_rating())] for s in players]
+        teams = [[ratings.setdefault(s, env.create_rating())] for s in players]
 
         if len(teams) < 2:
             continue  # need at least two teams for a rating update
@@ -101,10 +99,19 @@ def _update_ratings(
     return {k: (r.mu, r.sigma) for k, r in ratings.items()}
 
 
-def run_trueskill(seed: int = 0) -> None:
+def run_trueskill(output_seed: int = 0) -> None:
+    """Compute TrueSkill ratings from previous tournament results.
+
+    Parameters
+    ----------
+    output_seed:
+        Value appended to output filenames so repeated runs do not overwrite
+        earlier results.
+    """
+
     base = Path("data/results")
     manifest_seed = _read_manifest_seed(base / "manifest.yaml")
-    suffix = f"_seed{seed}" if seed != manifest_seed else ""
+    suffix = f"_seed{output_seed}" if output_seed != manifest_seed else ""
     env = trueskill.TrueSkill()
     pooled: Dict[str, tuple[float, float]] = {}
     for block in sorted(base.glob("*_players")):
@@ -131,12 +138,16 @@ def run_trueskill(seed: int = 0) -> None:
 
 def main(argv: List[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Compute TrueSkill ratings")
-    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--output-seed",
+        type=int,
+        default=0,
+        help="only used to name output files",
+    )
     args = parser.parse_args(argv or [])
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    run_trueskill(seed=args.seed)
+    run_trueskill(output_seed=args.output_seed)
 
 
 if __name__ == "__main__":
     main()
-    

--- a/tests/unit/test_analysis_pipeline.py
+++ b/tests/unit/test_analysis_pipeline.py
@@ -45,7 +45,7 @@ def test_analysis_pipeline(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        run_trueskill.main([])
+        run_trueskill.main(["--output-seed", "0"])
         run_rf.main([])
 
         with open("data/ratings_pooled.pkl", "rb") as fh:
@@ -68,4 +68,3 @@ def test_analysis_pipeline(tmp_path):
         )
     finally:
         os.chdir(cwd)
-        


### PR DESCRIPTION
## Summary
- rename `seed` param in `run_trueskill` to `output_seed`
- expose new `--output-seed` CLI arg and explain its purpose
- adjust `test_analysis_pipeline` for the new flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c6457e3b8832fb2d7581312c58d4c