### PR TITLE
Use dataclass for rating stats

### DIFF
--- a/src/farkle/run_rf.py
+++ b/src/farkle/run_rf.py
@@ -17,7 +17,7 @@ def run_rf(seed: int = 0) -> None:
     metrics = pd.read_parquet("data/metrics.parquet")
     with open("data/ratings_pooled.pkl", "rb") as fh:
         ratings = pickle.load(fh)
-    df_mu = pd.DataFrame({"strategy": list(ratings), "mu": [v[0] for v in ratings.values()]})
+    df_mu = pd.DataFrame({"strategy": list(ratings), "mu": [v.mu for v in ratings.values()]})
     data = metrics.merge(df_mu, on="strategy", how="inner")
     X = data.drop(columns=["strategy", "mu"])
     X = X.astype(float)

--- a/tests/unit/test_run_trueskill_helpers.py
+++ b/tests/unit/test_run_trueskill_helpers.py
@@ -71,5 +71,5 @@ def test_update_ratings_ranked():
       new = env.rate([[ratings[p[0]]], [ratings[p[1]]]], ranks=[0, 1])
       ratings[p[0]], ratings[p[1]] = new[0][0], new[1][0]
 
-    expected = {k: (r.mu, r.sigma) for k, r in ratings.items()}
+    expected = {k: rt.RatingStats(r.mu, r.sigma) for k, r in ratings.items()}
     assert result == expected


### PR DESCRIPTION
## Summary
- add `RatingStats` dataclass for TrueSkill results
- update `_update_ratings` and `run_trueskill` to use it
- adjust RF routine and related unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c645b4768832f85222ae8054b3005