### PR TITLE
Add robust TrueSkill helper tests

### DIFF
--- a/tests/unit/test_run_trueskill_helpers.py
+++ b/tests/unit/test_run_trueskill_helpers.py
@@ -1,4 +1,9 @@
+import os
+import pickle
+
+import numpy as np
 import pandas as pd
+import pytest
 import trueskill
 
 import farkle.run_trueskill as rt
@@ -12,7 +17,7 @@ def test_read_manifest_seed(tmp_path):
 
 
 def test_load_ranked_games_parquet(tmp_path):
-    block   = tmp_path / "b_players"
+    block = tmp_path / "b_players"
     row_dir = block / "1_rows"
     row_dir.mkdir(parents=True)
     pd.DataFrame({"winner_strategy": ["A"]}).to_parquet(row_dir / "a.parquet")
@@ -23,15 +28,17 @@ def test_load_ranked_games_parquet(tmp_path):
 
 
 def test_load_ranked_games_rank_based(tmp_path):
-    block   = tmp_path / "r_players"
+    block = tmp_path / "r_players"
     row_dir = block / "1_rows"
     row_dir.mkdir(parents=True)
-    df = pd.DataFrame({
-        "P1_strategy": ["A"],
-        "P1_rank":     [1],
-        "P2_strategy": ["B"],
-        "P2_rank":     [2],
-    })
+    df = pd.DataFrame(
+        {
+            "P1_strategy": ["A"],
+            "P1_rank": [1],
+            "P2_strategy": ["B"],
+            "P2_rank": [2],
+        }
+    )
     df.to_parquet(row_dir / "rows.parquet")
 
     games = rt._load_ranked_games(block)
@@ -52,24 +59,74 @@ def test_update_ratings_ranked():
 
     # original winner stream:  A, B, A, C, A
     games = [
-        ["A", "B"],   # A beats B
-        ["B", "A"],   # B beats A
-        ["A", "C"],   # A beats C
-        ["C", "A"],   # C beats A
-        ["A", "B"],   # A beats B again
+        ["A", "B"],  # A beats B
+        ["B", "A"],  # B beats A
+        ["A", "C"],  # A beats C
+        ["C", "A"],  # C beats A
+        ["A", "B"],  # A beats B again
     ]
 
-    keepers = ["A", "B"]                     # only rate these two
+    keepers = ["A", "B"]  # only rate these two
     result = rt._update_ratings(games, keepers, env)
 
     # build the expected ratings by replaying the same tables
     ratings = {k: env.create_rating() for k in keepers}
     for g in games:
-      p = [s for s in g if s in keepers]
-      if len(p) < 2:
-          continue
-      new = env.rate([[ratings[p[0]]], [ratings[p[1]]]], ranks=[0, 1])
-      ratings[p[0]], ratings[p[1]] = new[0][0], new[1][0]
+        p = [s for s in g if s in keepers]
+        if len(p) < 2:
+            continue
+        new = env.rate([[ratings[p[0]]], [ratings[p[1]]]], ranks=[0, 1])
+        ratings[p[0]], ratings[p[1]] = new[0][0], new[1][0]
 
     expected = {k: (r.mu, r.sigma) for k, r in ratings.items()}
     assert result == expected
+
+
+def test_load_ranked_games_empty(tmp_path):
+    block = tmp_path / "empty_players"
+    block.mkdir()
+    assert rt._load_ranked_games(block) == []
+
+
+def test_load_ranked_games_missing_strategy(tmp_path):
+    block = tmp_path / "bad_players"
+    row_dir = block / "2_rows"
+    row_dir.mkdir(parents=True)
+    df = pd.DataFrame({"P1_rank": [1], "P2_rank": [2], "P2_strategy": ["B"]})
+    df.to_parquet(row_dir / "rows.parquet")
+    with pytest.raises(KeyError):
+        rt._load_ranked_games(block)
+
+
+def test_run_trueskill_incomplete_block(tmp_path):
+    data_root = tmp_path / "data"
+    res_dir = data_root / "results"
+    res_dir.mkdir(parents=True)
+
+    block_good = res_dir / "2_players"
+    block_good.mkdir()
+    np.save(block_good / "keepers_2.npy", np.array(["A", "B"]))
+    pd.DataFrame({"winner_strategy": ["A", "B"]}).to_csv(block_good / "winners.csv", index=False)
+
+    block_empty = res_dir / "3_players"
+    block_empty.mkdir()
+
+    (res_dir / "manifest.yaml").write_text("seed: 0\n")
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        rt.run_trueskill(seed=0)
+    finally:
+        os.chdir(cwd)
+
+    with open(data_root / "ratings_2.pkl", "rb") as fh:
+        good = pickle.load(fh)
+    with open(data_root / "ratings_3.pkl", "rb") as fh:
+        empty = pickle.load(fh)
+    with open(data_root / "ratings_pooled.pkl", "rb") as fh:
+        pooled = pickle.load(fh)
+
+    assert good
+    assert empty == {}
+    assert set(pooled) == set(good)


### PR DESCRIPTION
## Summary
- add coverage for _load_ranked_games edge cases and run_trueskill
- verify no data returns an empty list
- check missing strategy columns raise KeyError
- ensure run_trueskill ignores incomplete blocks

## Testing
- `ruff check tests/unit/test_run_trueskill_helpers.py`
- `black --check tests/unit/test_run_trueskill_helpers.py`
- `pytest tests/unit/test_run_trueskill_helpers.py::test_run_trueskill_incomplete_block -q`

------
https://chatgpt.com/codex/tasks/task_e_687c645cf8c8832fb6808c9291d7d37c