### PR TITLE
Validate dice faces

### DIFF
--- a/src/farkle/scoring.py
+++ b/src/farkle/scoring.py
@@ -53,7 +53,14 @@ def faces_to_counts_tuple(faces: Sequence[int]) -> Counts6:
     -------
     Counts6:
         Six-element tuple of counts for faces one through six.
+
+    Raises
+    ------
+    ValueError:
+        If any face value is outside the ``1``–``6`` range.
     """
+    if not all(1 <= f <= 6 for f in faces):
+        raise ValueError("dice faces must be between 1 and 6")
     return _faces_to_counts_nb(np.asarray(faces, dtype=np.int64))
 
 

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -301,3 +301,18 @@ def test_default_score_cases(dice_roll, turn_pre, threshold, smart5, smart1, exp
         dice_threshold = 3,
     )
     assert out == expected
+
+
+@pytest.mark.parametrize(
+    "faces",
+    [
+        [0, 1, 2],
+        [1, 2, 7],
+        [-1, 3, 4],
+    ],
+)
+def test_faces_to_counts_tuple_invalid_faces(faces):
+    import farkle.scoring as scoring
+
+    with pytest.raises(ValueError):
+        scoring.faces_to_counts_tuple(faces)


### PR DESCRIPTION
## Summary
- raise a ValueError in `faces_to_counts_tuple` on out-of-range faces
- document the new ValueError in the docstring
- test invalid face handling in scoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c64776870832f9520c767ee66a925