### PR TITLE
Use builtin generics for scoring lookup

### DIFF
--- a/src/farkle/scoring_lookup.py
+++ b/src/farkle/scoring_lookup.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from functools import lru_cache
 from itertools import combinations_with_replacement
-from typing import Dict, Tuple
 
 import numba as nb
 import numpy as np
@@ -16,7 +15,7 @@ from farkle.types import Counts6, Int64Arr1D
 
 
 @nb.njit(cache=True)
-def _straight(ctr: Int64Arr1D) -> Tuple[int, int]:
+def _straight(ctr: Int64Arr1D) -> tuple[int, int]:
     """Return the straight bonus if every face appears once.
 
     Args:
@@ -30,7 +29,7 @@ def _straight(ctr: Int64Arr1D) -> Tuple[int, int]:
 
 
 @nb.njit(cache=True)
-def _three_pairs(ctr: Int64Arr1D) -> Tuple[int, int]:
+def _three_pairs(ctr: Int64Arr1D) -> tuple[int, int]:
     """Detect the *three pairs* pattern.
 
     Args:
@@ -45,7 +44,7 @@ def _three_pairs(ctr: Int64Arr1D) -> Tuple[int, int]:
 
 
 @nb.njit(cache=True)
-def _two_triplets(ctr: Int64Arr1D) -> Tuple[int, int]:
+def _two_triplets(ctr: Int64Arr1D) -> tuple[int, int]:
     """Detect the *two triplets* pattern.
 
     Args:
@@ -60,7 +59,7 @@ def _two_triplets(ctr: Int64Arr1D) -> Tuple[int, int]:
 
 
 @nb.njit(cache=True)
-def _four_kind_plus_pair(ctr: Int64Arr1D) -> Tuple[int, int]:
+def _four_kind_plus_pair(ctr: Int64Arr1D) -> tuple[int, int]:
     """Check for four of a kind together with a separate pair.
 
     Args:
@@ -77,13 +76,14 @@ def _four_kind_plus_pair(ctr: Int64Arr1D) -> Tuple[int, int]:
 # 1.  Master evaluator (Numba core + pure-Python wrapper)
 # ---------------------------------------------------------------------------
 
+
 @nb.njit(cache=True)
 def _evaluate_nb(
-    c1: int, 
-    c2: int, 
-    c3: int, 
-    c4: int, 
-    c5: int, 
+    c1: int,
+    c2: int,
+    c3: int,
+    c4: int,
+    c5: int,
     c6: int,
 ) -> tuple[int, int, int, int]:
     """Score a roll purely within Numba.
@@ -166,7 +166,7 @@ def evaluate(counts: Counts6) -> tuple[int, int, int, int]:
     return _evaluate_nb(*counts)
 
 
-def score_roll(roll: list[int]) -> Tuple[int, int]:
+def score_roll(roll: list[int]) -> tuple[int, int]:
     """Score a roll given as a list of faces.
 
     Args:
@@ -177,11 +177,11 @@ def score_roll(roll: list[int]) -> Tuple[int, int]:
         and how many dice contributed to the score.
     """
     key = (
-        roll.count(1), 
-        roll.count(2), 
+        roll.count(1),
+        roll.count(2),
         roll.count(3),
-        roll.count(4), 
-        roll.count(5), 
+        roll.count(4),
+        roll.count(5),
         roll.count(6),
     )
     pts, used, *_ = evaluate(key)
@@ -197,7 +197,7 @@ def build_score_lookup_table() -> dict[Counts6, tuple[int, int, Counts6, int, in
     """
     Fast O(1) table for any ≤6-dice roll.
     Loads pre-computed scores for every multiset of up to six dice.
-    
+
     Inputs:
         None
 
@@ -207,17 +207,21 @@ def build_score_lookup_table() -> dict[Counts6, tuple[int, int, Counts6, int, in
         first element is the total points for that combination and
         counts repeats the key so callers can keep a reference.
     """
-    look: Dict[
-        Tuple[int, int, int, int, int, int], 
-        Tuple[int, int, Tuple[int, int, int, int, int, int], int, int]
+    look: dict[
+        tuple[int, int, int, int, int, int],
+        tuple[int, int, tuple[int, int, int, int, int, int], int, int],
     ] = {}
     faces = range(1, 7)
 
     for n in range(1, 7):
         for multiset in combinations_with_replacement(faces, n):
             key = (
-                multiset.count(1), multiset.count(2), multiset.count(3),
-                multiset.count(4), multiset.count(5), multiset.count(6),
+                multiset.count(1),
+                multiset.count(2),
+                multiset.count(3),
+                multiset.count(4),
+                multiset.count(5),
+                multiset.count(6),
             )
             if key in look:  # skip duplicates (e.g. (2,2,2,5,5) permutes)
                 continue

--- a/src/farkle/watch_game.py
+++ b/src/farkle/watch_game.py
@@ -82,7 +82,7 @@ def _trace_decide(s: ThresholdStrategy, label: str) -> None:
         return keep
 
     # bind as *method* so `self` is passed correctly
-    s.decide = MethodType(traced_decide, s)  # type: ignore[attr-defined]
+    s.decide = MethodType(traced_decide, s)  # type: ignore[attr-defined, method-assign]
 
 
 def _patch_default_score() -> None:
@@ -107,7 +107,7 @@ def _patch_default_score() -> None:
 class TracePlayer(FarklePlayer):
     """Subclass that only adds a noisy _roll()."""
 
-    def _roll(self, n: int) -> Sequence[int]:  # :contentReference[oaicite:3]{index=3}
+    def _roll(self, n: int) -> list[int]:  # :contentReference[oaicite:3]{index=3}
         faces = super()._roll(n)
         log.info(f"{self.name} rolls {faces}")
         return faces


### PR DESCRIPTION
## Summary
- drop `Dict`/`Tuple` typing imports
- adopt builtin `dict[...]` and `tuple[...]` generics
- keep mypy happy by improving a few annotations
- adjust `farkle_io`, `run_tournament`, and `watch_game` for mypy

## Testing
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c64ad2108832fab8ac4a7dcbec043