### PR TITLE
Add validation for evaluate counts

### DIFF
--- a/src/farkle/scoring_lookup.py
+++ b/src/farkle/scoring_lookup.py
@@ -157,12 +157,22 @@ def evaluate(counts: Counts6) -> tuple[int, int, int, int]:
         Hash friendly for Numba.
 
     Args:
-        counts: A 6-tuple giving the number of dice showing each face.
+        counts: A 6-tuple giving the number of dice showing each face. The
+            tuple must consist of six non-negative integers whose sum does not
+            exceed six.
 
     Returns:
         (score, used, single_fives, single_ones) in the same format
         as :func:`_evaluate_nb`.
     """
+    if (
+        len(counts) != 6
+        or not all(isinstance(x, int) and x >= 0 for x in counts)
+        or sum(counts) > 6
+    ):
+        raise ValueError(
+            "counts must contain six non-negative integers totaling at most six"
+        )
     return _evaluate_nb(*counts)
 
 


### PR DESCRIPTION
## Summary
- validate the counts tuple in `evaluate`
- document new constraints in the docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c64af4df8832fb0b6ff5ff88e2ba1