### PR TITLE
Simplify strategy grid generation

### DIFF
--- a/src/farkle/simulation.py
+++ b/src/farkle/simulation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import multiprocessing as mp
+import itertools
 from dataclasses import asdict
 from typing import Any, Dict, List, Sequence, Tuple
 
@@ -66,35 +67,34 @@ def generate_strategy_grid(
     if smart_one_opts is None:
         smart_one_opts = [True, False] 
     combos: List[Tuple[int, int, bool, bool, bool, bool, bool, bool, bool, bool]] = []
-    # We'll build combos of (st, dt, sm, cs, cd, require_both)
-    for rs in run_up_score_opts:  # 2 options
-        for hd in auto_hot_opts:  # Hot Dice 2 options
-            for st in score_thresholds:  # 17 options
-                for dt in dice_thresholds:  # 5 options
-                    for sf in smart_five_opts:  # 2 options
-                        for so in smart_one_opts:  # 1.5 options
-                            if not sf and so:  # Can't be smart one without being smart five
-                                continue  # You technically could but it makes no strategic sense irl
-                            for cs in consider_score_opts:  # 2 options
-                                for cd in consider_dice_opts:  # 2.5 options (1/4 of cs&cd gets an extra option on rb 4+1 = 5, 5/2 = 2.5)
-                                    # Determine the two valid values of require_both:
-                                    rb_values = [True, False] if cs and cd else [False]
-                                    for rb in rb_values:
-                                        # Now we need to pick prefer_score (ps) according to:
-                                        #   cs  cd   ⟶  valid ps
-                                        #   T   F       True
-                                        #   F   T       False
-                                        #   T   T       both {True, False}
-                                        #   F   F       both {True, False}
-                                        if cs and not cd:
-                                            ps_values = [True]
-                                        elif cd and not cs:
-                                            ps_values = [False]
-                                        else:
-                                            # (cs,cd) is either (T,T) or (F,F)
-                                            ps_values = [True, False]
-                                        for ps in ps_values:  # 1.6 options (Increases cs,cd,rb truth table from 5 to 8 with cs,cd,rb,ps 8/5 = 1.6)
-                                            combos.append((st, dt, sf, so, cs, cd, rb, hd, rs, ps))
+
+    # Iterate over the basic option grid using itertools.product and filter
+    for st, dt, sf, so, cs, cd, hd, rs in itertools.product(
+        score_thresholds,
+        dice_thresholds,
+        smart_five_opts,
+        smart_one_opts,
+        consider_score_opts,
+        consider_dice_opts,
+        auto_hot_opts,
+        run_up_score_opts,
+    ):
+        # Can't be smart one without smart five
+        if not sf and so:
+            continue
+
+        rb_values = [True, False] if cs and cd else [False]
+
+        if cs and not cd:
+            ps_values = [True]
+        elif cd and not cs:
+            ps_values = [False]
+        else:
+            ps_values = [True, False]
+
+        for rb in rb_values:
+            for ps in ps_values:
+                combos.append((st, dt, sf, so, cs, cd, rb, hd, rs, ps))
 
     # Build actual strategy objects and a DataFrame
     strategies = [


### PR DESCRIPTION
## Summary
- refactor generate_strategy_grid to build combinations via itertools.product
- add itertools import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c64c82598832fae3f2dbdabfc7199