### PR TITLE
Rename auto_hot_opts argument

### DIFF
--- a/src/farkle/simulation.py
+++ b/src/farkle/simulation.py
@@ -45,7 +45,7 @@ def generate_strategy_grid(
     smart_one_opts: Sequence[bool] | None = None,
     consider_score_opts: Sequence[bool] = (True, False),
     consider_dice_opts: Sequence[bool] = (True, False),
-    auto_hot_opts: Sequence[bool] = (False, True),
+    auto_hot_dice_opts: Sequence[bool] = (False, True),
     run_up_score_opts: Sequence[bool] = (True, False),
 ) -> Tuple[List[ThresholdStrategy], pd.DataFrame]:
     """Create the Cartesian product of all parameter options.
@@ -68,7 +68,7 @@ def generate_strategy_grid(
     combos: List[Tuple[int, int, bool, bool, bool, bool, bool, bool, bool, bool]] = []
     # We'll build combos of (st, dt, sm, cs, cd, require_both)
     for rs in run_up_score_opts:  # 2 options
-        for hd in auto_hot_opts:  # Hot Dice 2 options
+        for hd in auto_hot_dice_opts:  # Hot Dice 2 options
             for st in score_thresholds:  # 17 options
                 for dt in dice_thresholds:  # 5 options
                     for sf in smart_five_opts:  # 2 options

--- a/tests/integration/test_farkle_integration.py
+++ b/tests/integration/test_farkle_integration.py
@@ -88,7 +88,7 @@ def test_cli_smoke(tmp_path: Path):
             "smart_one_opts": [False],
             "consider_score_opts": [True],
             "consider_dice_opts": [True],
-            "auto_hot_opts": [False],
+            "auto_hot_dice_opts": [False],
         },
         "sim": {
             "n_games": 20,

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -46,7 +46,7 @@ def test_play_helpers_consistency():
 
 def test_custom_grid_size():
     # Only auto_hot_dice == True → half the default grid (1 275)
-    strategies, meta = generate_strategy_grid(auto_hot_opts=[True])
+    strategies, meta = generate_strategy_grid(auto_hot_dice_opts=[True])
     assert len(strategies) == 4080
     assert len(meta) == 4080
     

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -26,7 +26,7 @@ def test_cli_run(tmp_path, monkeypatch):
             "smart_one_opts": [False],
             "consider_score_opts": [True],
             "consider_dice_opts": [True],
-            "auto_hot_opts": [False],
+            "auto_hot_dice_opts": [False],
         },
         "sim": {
             "n_games": 2,


### PR DESCRIPTION
## Summary
- rename `auto_hot_opts` to `auto_hot_dice_opts`
- update unit and integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c64c8ca1c832fa7014ffb7ed4da31