### PR TITLE
Add winner sanity check

### DIFF
--- a/src/farkle/simulation.py
+++ b/src/farkle/simulation.py
@@ -60,11 +60,11 @@ def generate_strategy_grid(
     if score_thresholds is None:
         score_thresholds = list(range(200, 1050, 50))
     if dice_thresholds is None:
-        dice_thresholds = list(range(0, 5)) 
+        dice_thresholds = list(range(0, 5))
     if smart_five_opts is None:
-        smart_five_opts = [True, False] 
+        smart_five_opts = [True, False]
     if smart_one_opts is None:
-        smart_one_opts = [True, False] 
+        smart_one_opts = [True, False]
     combos: List[Tuple[int, int, bool, bool, bool, bool, bool, bool, bool, bool]] = []
     # We'll build combos of (st, dt, sm, cs, cd, require_both)
     for rs in run_up_score_opts:  # 2 options
@@ -76,7 +76,11 @@ def generate_strategy_grid(
                             if not sf and so:  # Can't be smart one without being smart five
                                 continue  # You technically could but it makes no strategic sense irl
                             for cs in consider_score_opts:  # 2 options
-                                for cd in consider_dice_opts:  # 2.5 options (1/4 of cs&cd gets an extra option on rb 4+1 = 5, 5/2 = 2.5)
+                                for (
+                                    cd
+                                ) in (
+                                    consider_dice_opts
+                                ):  # 2.5 options (1/4 of cs&cd gets an extra option on rb 4+1 = 5, 5/2 = 2.5)
                                     # Determine the two valid values of require_both:
                                     rb_values = [True, False] if cs and cd else [False]
                                     for rb in rb_values:
@@ -93,22 +97,26 @@ def generate_strategy_grid(
                                         else:
                                             # (cs,cd) is either (T,T) or (F,F)
                                             ps_values = [True, False]
-                                        for ps in ps_values:  # 1.6 options (Increases cs,cd,rb truth table from 5 to 8 with cs,cd,rb,ps 8/5 = 1.6)
+                                        for (
+                                            ps
+                                        ) in (
+                                            ps_values
+                                        ):  # 1.6 options (Increases cs,cd,rb truth table from 5 to 8 with cs,cd,rb,ps 8/5 = 1.6)
                                             combos.append((st, dt, sf, so, cs, cd, rb, hd, rs, ps))
 
     # Build actual strategy objects and a DataFrame
     strategies = [
         ThresholdStrategy(
-            score_threshold = st,
-            dice_threshold = dt,
-            smart_five = sf,
-            smart_one = so,
-            consider_score = cs,
-            consider_dice = cd,
-            require_both = rb,
-            auto_hot_dice = hd,
-            run_up_score = rs,
-            prefer_score = ps,
+            score_threshold=st,
+            dice_threshold=dt,
+            smart_five=sf,
+            smart_one=so,
+            consider_score=cs,
+            consider_dice=cd,
+            require_both=rb,
+            auto_hot_dice=hd,
+            run_up_score=rs,
+            prefer_score=ps,
         )
         for st, dt, sf, so, cs, cd, rb, hd, rs, ps in combos
     ]
@@ -116,15 +124,15 @@ def generate_strategy_grid(
     meta = pd.DataFrame(
         combos,
         columns=[
-            "score_threshold", 
-            "dice_threshold", 
-            "smart_five", 
-            "smart_one", 
-            "consider_score", 
-            "consider_dice", 
-            "require_both", 
-            "auto_hot_dice", 
-            "run_up_score", 
+            "score_threshold",
+            "dice_threshold",
+            "smart_five",
+            "smart_one",
+            "consider_score",
+            "consider_dice",
+            "require_both",
+            "auto_hot_dice",
+            "run_up_score",
             "prefer_score",
         ],
     )
@@ -143,10 +151,14 @@ def experiment_size(
     run_up_score_opts: Sequence[bool] = (True, False),
 ) -> int:
     """Compute *a priori* size of a strategy grid."""
-    
+
     score_thresholds = score_thresholds or list(range(200, 1050, 50))
     dice_thresholds = dice_thresholds or list(range(0, 5))
-    smart_five_and_one_options = smart_five_and_one_options or [[True, True], [True, False], [False, False]]
+    smart_five_and_one_options = smart_five_and_one_options or [
+        [True, True],
+        [True, False],
+        [False, False],
+    ]
     base = (
         len(score_thresholds)
         * len(dice_thresholds)
@@ -162,10 +174,13 @@ def experiment_size(
     # Extra row for (True, True) when it's present
     if True in consider_score_opts and True in consider_dice_opts:
         pair_count += 1  # second variant with require_both=True
-    
-    pair_count += 3 # prefer score adds an extra option for each cs,cd TT (2 of them) or FF combination
+
+    pair_count += (
+        3  # prefer score adds an extra option for each cs,cd TT (2 of them) or FF combination
+    )
 
     return base * pair_count
+
 
 # ---------------------------------------------------------------------------
 # Batch simulation helpers
@@ -173,21 +188,28 @@ def experiment_size(
 def _make_players(strategies, seed):
     master = np.random.default_rng(seed)
     return [
-      FarklePlayer(
-        name=f"P{i+1}",
-        strategy=s,
-        rng=np.random.default_rng(master.integers(0, 2**32 - 1)),
-      )
-      for i, s in enumerate(strategies)
+        FarklePlayer(
+            name=f"P{i+1}",
+            strategy=s,
+            rng=np.random.default_rng(master.integers(0, 2**32 - 1)),
+        )
+        for i, s in enumerate(strategies)
     ]
 
 
-def _play_game(seed: int, strategies: Sequence[ThresholdStrategy], target_score: int=10000) -> Dict[str, Any]:
+def _play_game(
+    seed: int, strategies: Sequence[ThresholdStrategy], target_score: int = 10000
+) -> Dict[str, Any]:
     # give every player an *independent* PRNG, but reproducible
     players = _make_players(strategies, seed)
     gm = FarkleGame(players, target_score=target_score).play()
     # 1) Determine the winning player's name from the PlayerStats block
-    winner = next(name for name, ps in gm.players.items() if ps.rank == 1)
+    winners = [name for name, ps in gm.players.items() if ps.rank == 1]
+    if len(winners) != 1:
+        raise ValueError(
+            f"Expected exactly one player with rank == 1, got {len(winners)}: {winners}"
+        )
+    winner = winners[0]
     flat: Dict[str, Any] = {
         "winner": winner,
         "winning_score": gm.players[winner].score,
@@ -198,7 +220,7 @@ def _play_game(seed: int, strategies: Sequence[ThresholdStrategy], target_score:
         # asdict works on slots dataclasses
         for k, v in asdict(stats).items():
             flat[f"{pname}_{k}"] = v
-            
+
     return flat
 
 
@@ -211,7 +233,7 @@ def simulate_many_games(
     n_jobs: int = 1,
 ) -> pd.DataFrame:
     """Run *n_games* in parallel (if *n_jobs>1*) and return tidy metrics."""
-    
+
     master_rng = np.random.default_rng(seed)
     seeds = master_rng.integers(0, 2**32 - 1, size=n_games).tolist()
     args = [(s, strategies, target_score) for s in seeds]
@@ -230,7 +252,7 @@ def simulate_one_game(
     seed: int | None = None,
 ):
     """Convenience wrapper around the *single* game engine."""
-    
+
     players = _make_players(strategies, seed)
     return FarkleGame(players, target_score=target_score).play()
 
@@ -239,9 +261,10 @@ def simulate_one_game(
 # Aggregation helper
 # ---------------------------------------------------------------------------
 
+
 def aggregate_metrics(df: pd.DataFrame) -> Dict[str, Any]:
     """Return a *dict* with high-level summary statistics."""
-    
+
     return {
         "games": len(df),
         "avg_rounds": df["n_rounds"].mean(),


### PR DESCRIPTION
## Summary
- ensure a single winner emerges in `_play_game`
- add unit test to verify winner sanity check

## Testing
- `ruff check tests/unit/test_simulation.py src/farkle/simulation.py`
- `black tests/unit/test_simulation.py src/farkle/simulation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c64cbcbec832f882c8b895120d55f