### PR TITLE
Fix typos and update strategy parser docs

### DIFF
--- a/src/farkle/strategies.py
+++ b/src/farkle/strategies.py
@@ -123,7 +123,7 @@ class ThresholdStrategy:
         
         Counterintuitively, require_both = True is riskier play
         
-        Outcomes of cominations of consider_score = True, consider_dice = True, 
+        Outcomes of combinations of consider_score = True, consider_dice = True,
         require_both = [True, False] for score_threshold = 300 and dice_threshold = 3:
          
         cs and cd are True, require_both = True (AND logic)
@@ -161,7 +161,7 @@ class ThresholdStrategy:
     # Representation helpers
     # ------------------------------------------------------------------
     
-    def __str__(self) -> str:  # noqa: D401 - magics method
+    def __str__(self) -> str:  # noqa: D401 - magic method
         cs = "S" if self.consider_score else "-"
         cd = "D" if self.consider_dice else "-"
         sf = "F" if self.smart_five else "-"
@@ -252,9 +252,9 @@ def parse_strategy(s: str) -> ThresholdStrategy:
     #     auto_hot       = "H" or "-"
     #     run_up_score   = "R" or "-"
     #     require_both   = "AND" or "OR"
-    #     prefer_score   = "P" or "-"
+    #     prefer_score   = "PS" or "PD"
     #
-    # Example literal: "Strat(300,2)[SD][F-O][AND][H-]"
+    # Example literal: "Strat(300,2)[SD][FOPD][AND][H-]"
 
     pattern = re.compile(
         r"""
@@ -345,9 +345,9 @@ def parse_strategy_for_df(s: str) -> dict:
     #     auto_hot       = "H" or "-"
     #     run_up_score   = "R" or "-"
     #     require_both   = "AND" or "OR"
-    #     prefer_score   = "P" or "-"
+    #     prefer_score   = "PS" or "PD"
     #
-    # Example literal: "Strat(300,2)[SD][F-O][AND][H-]"
+    # Example literal: "Strat(300,2)[SD][FOPD][AND][H-]"
 
     pattern = re.compile(
         r"""


### PR DESCRIPTION
## Summary
- correct typos in `strategies.py`
- update comments for `parse_strategy` and `parse_strategy_for_df`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c65196160832fac35cdb6552b03ea