### PR TITLE
Move DiceRoll alias to shared types module

### DIFF
--- a/src/farkle/scoring.py
+++ b/src/farkle/scoring.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import functools
-from typing import List, Sequence, Tuple, cast
+from typing import Sequence, Tuple, cast
 
 # Numba is only used in the low-level helpers;
 # no caller needs to install it explicitly.
@@ -10,14 +10,12 @@ import numba as nb
 import numpy as np
 
 from farkle.scoring_lookup import evaluate as _eval_nb  # fast JIT core
-from farkle.types import Counts6, FacesT, Int64Arr1D
+from farkle.types import Counts6, FacesT, Int64Arr1D, DiceRoll
 
 # --------------------------------------------------------------------------- #
 # 0.  Public type alias
 # --------------------------------------------------------------------------- #
-DiceRoll = List[int]  # a raw roll as a list of faces
-
-
+# DiceRoll is imported from :mod:`farkle.types`
 # --------------------------------------------------------------------------- #
 # 1.  Tiny helpers – all immutable / hash-friendly
 # --------------------------------------------------------------------------- #

--- a/src/farkle/strategies.py
+++ b/src/farkle/strategies.py
@@ -5,7 +5,7 @@ import random
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable
 
 import numba as nb
 import pandas as pd
@@ -34,8 +34,7 @@ __all__: list[str] = [
 ]
 
 
-DiceRoll = List[int]
-"""A list of integers 1-6 representing a single dice roll."""
+from farkle.types import DiceRoll
 
 
 # ---------------------------------------------------------------------------

--- a/src/farkle/types.py
+++ b/src/farkle/types.py
@@ -7,3 +7,4 @@ import numpy.typing as npt
 Counts6: TypeAlias = Tuple[int, int, int, int, int, int]
 FacesT: TypeAlias = Tuple[int, ...]
 Int64Arr1D: TypeAlias = npt.NDArray[np.int64]
+DiceRoll: TypeAlias = list[int]


### PR DESCRIPTION
## Summary
- centralize DiceRoll alias with other type aliases
- import DiceRoll from `farkle.types` in `strategies` and `scoring`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c651dbb00832f98f2f7c7c44ef398