### PR TITLE
Add pickle security warning

### DIFF
--- a/src/farkle/strategies.py
+++ b/src/farkle/strategies.py
@@ -421,6 +421,11 @@ def load_farkle_results(
     Load a pickled Counter {strategy_str: wins} and explode it into a
     “full-fat” DataFrame with every strategy flag broken out.
 
+    Warning
+    -------
+    Unpickling data from untrusted sources can execute arbitrary code.
+    Only load pickle files from trusted sources.
+
     Parameters
     ----------
     pkl_path : str | Path


### PR DESCRIPTION
## Summary
- warn users about untrusted pickle files in `load_farkle_results` docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c6523433c832f992597f767c0ad3d