### PR TITLE
Fix docstrings in time_farkle

### DIFF
--- a/src/farkle/time_farkle.py
+++ b/src/farkle/time_farkle.py
@@ -19,41 +19,32 @@ from farkle.simulation import (
     simulate_many_games,
     simulate_one_game,
 )
-from farkle.strategies import random_threshold_strategy
+from farkle.strategies import ThresholdStrategy, random_threshold_strategy
 
 
-def make_random_strategies(num_players: int, seed: int | None) -> list:
-    """Summary
-    -------
-    Generates a list of random ThresholdStrategy objects for each player.
+def make_random_strategies(num_players: int, seed: int | None) -> list[ThresholdStrategy]:
+    """Generate random strategies for each player.
 
-    Inputs
-    ------
-    num_players: int 
-    seed: int | None
+    Args:
+        num_players: Number of players in the game.
+        seed: Seed for deterministic randomness.
 
-    Returns
-    -------
-    list
-        Randomly generated ThresholdStrategy objects
+    Returns:
+        list[ThresholdStrategy]:
+            Randomly generated ``ThresholdStrategy`` objects.
     """
     rng = random.Random(seed)
     return [random_threshold_strategy(rng) for _ in range(num_players)]
 
 
 def measure_sim_times(argv: list[str] | None = None):
-    """Summary
-    -------
-    Run timing benchmarks for one game and a batch of games.
+    """Run timing benchmarks for one game and a batch of games.
 
-    Inputs
-    ------
-    argv : list[str] | None, optional
-        Argument list to parse instead of ``sys.argv``.
+    Args:
+        argv: Optional argument list to parse instead of ``sys.argv``.
 
-    Returns
-    -------
-    None
+    Returns:
+        None
     """
     p = argparse.ArgumentParser(
         description="Time one Farkle game and a batch of N games."


### PR DESCRIPTION
## Summary
- update `make_random_strategies` type annotation
- rewrite docstrings in `src/farkle/time_farkle.py` using Google style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c65471e78832f8f39424d147c4e31