### PR TITLE
Refactor argument parser in time_farkle

### DIFF
--- a/src/farkle/time_farkle.py
+++ b/src/farkle/time_farkle.py
@@ -22,6 +22,42 @@ from farkle.simulation import (
 from farkle.strategies import random_threshold_strategy
 
 
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Return the :class:`argparse.ArgumentParser` for the CLI."""
+    parser = argparse.ArgumentParser(
+        description="Time one Farkle game and a batch of N games.",
+    )
+    parser.add_argument(
+        "-n",
+        "--n_games",
+        type=int,
+        default=1000,
+        help="Number of games to simulate in batch",
+    )
+    parser.add_argument(
+        "-p",
+        "--players",
+        type=int,
+        default=5,
+        help="Number of players per game",
+    )
+    parser.add_argument(
+        "-s",
+        "--seed",
+        type=int,
+        default=42,
+        help="Master seed for reproducible RNG",
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=1,
+        help="Number of parallel processes",
+    )
+    return parser
+
+
 def make_random_strategies(num_players: int, seed: int | None) -> list:
     """Summary
     -------
@@ -29,7 +65,7 @@ def make_random_strategies(num_players: int, seed: int | None) -> list:
 
     Inputs
     ------
-    num_players: int 
+    num_players: int
     seed: int | None
 
     Returns
@@ -55,39 +91,18 @@ def measure_sim_times(argv: list[str] | None = None):
     -------
     None
     """
-    p = argparse.ArgumentParser(
-        description="Time one Farkle game and a batch of N games."
-    )
-    p.add_argument(
-        "-n", "--n_games", type=int, default=1000,
-        help="Number of games to simulate in batch"
-    )
-    p.add_argument(
-        "-p", "--players", type=int, default=5,
-        help="Number of players per game"
-    )
-    p.add_argument(
-        "-s", "--seed", type=int, default=42,
-        help="Master seed for reproducible RNG"
-    )
-    p.add_argument(
-        "-j", "--jobs", type=int, default=1,
-        help="Number of parallel processes"
-    )
-    args = p.parse_args(argv)
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
 
     # 1) Build a fixed roster of random strategies
     strategies = make_random_strategies(args.players, args.seed)
 
     # 2) Time a single game
     t0 = time.perf_counter()
-    gm = simulate_one_game(
-        strategies=strategies,
-        seed=args.seed
-    )
+    gm = simulate_one_game(strategies=strategies, seed=args.seed)
     t1 = time.perf_counter()
     print("\nSingle game:")
-    print(f"  Time elapsed      : {t1-t0:.6f} s")
+    print(f"  Time elapsed      : {t1 - t0:.6f} s")
     winner = max(gm.players.items(), key=lambda p: p[1].score)[0]
     print(f"  Winner            : {winner}")
     print(f"  Winning score     : {gm.players[winner].score}")
@@ -96,19 +111,18 @@ def measure_sim_times(argv: list[str] | None = None):
     # 3) Time a batch of N games
     t0 = time.perf_counter()
     df: pd.DataFrame = simulate_many_games(
-        n_games=args.n_games,
-        strategies=strategies,
-        seed=args.seed,
-        n_jobs=args.jobs
+        n_games=args.n_games, strategies=strategies, seed=args.seed, n_jobs=args.jobs
     )
     t1 = time.perf_counter()
     print(f"\nBatch of {args.n_games} games (jobs={args.jobs}):")
-    print(f"  Time elapsed      : {t1-t0:.6f} s")
+    print(f"  Time elapsed      : {t1 - t0:.6f} s")
     print("  Winners breakdown :")
     print(df["winner"].value_counts().to_string())
-    
+
+
 def main():
     measure_sim_times()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- rename `p` variable to `parser`
- add `build_arg_parser()` helper
- use new helper to parse arguments

## Testing
- `ruff format src/farkle/time_farkle.py`
- `ruff check src/farkle/time_farkle.py --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c65489be0832f86eb96ecd0f3b0ce