### PR TITLE
Add argument parser helper tests and CLI validation

### DIFF
--- a/src/farkle/time_farkle.py
+++ b/src/farkle/time_farkle.py
@@ -22,6 +22,52 @@ from farkle.simulation import (
 from farkle.strategies import random_threshold_strategy
 
 
+def _positive_int(value: str) -> int:
+    """Return ``value`` as ``int`` if it is strictly positive."""
+
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return ivalue
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser with validated defaults."""
+
+    p = argparse.ArgumentParser(
+        description="Time one Farkle game and a batch of N games.",
+    )
+    p.add_argument(
+        "-n",
+        "--n_games",
+        type=_positive_int,
+        default=1000,
+        help="Number of games to simulate in batch",
+    )
+    p.add_argument(
+        "-p",
+        "--players",
+        type=_positive_int,
+        default=5,
+        help="Number of players per game",
+    )
+    p.add_argument(
+        "-s",
+        "--seed",
+        type=int,
+        default=42,
+        help="Master seed for reproducible RNG",
+    )
+    p.add_argument(
+        "-j",
+        "--jobs",
+        type=_positive_int,
+        default=1,
+        help="Number of parallel processes",
+    )
+    return p
+
+
 def make_random_strategies(num_players: int, seed: int | None) -> list:
     """Summary
     -------
@@ -55,26 +101,8 @@ def measure_sim_times(argv: list[str] | None = None):
     -------
     None
     """
-    p = argparse.ArgumentParser(
-        description="Time one Farkle game and a batch of N games."
-    )
-    p.add_argument(
-        "-n", "--n_games", type=int, default=1000,
-        help="Number of games to simulate in batch"
-    )
-    p.add_argument(
-        "-p", "--players", type=int, default=5,
-        help="Number of players per game"
-    )
-    p.add_argument(
-        "-s", "--seed", type=int, default=42,
-        help="Master seed for reproducible RNG"
-    )
-    p.add_argument(
-        "-j", "--jobs", type=int, default=1,
-        help="Number of parallel processes"
-    )
-    args = p.parse_args(argv)
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
 
     # 1) Build a fixed roster of random strategies
     strategies = make_random_strategies(args.players, args.seed)

--- a/tests/unit/test_time_farkle.py
+++ b/tests/unit/test_time_farkle.py
@@ -66,4 +66,38 @@ def test_dataframe_winner_column(tmp_path, monkeypatch):  # noqa: ARG001
     monkeypatch.setattr(tf, "simulate_many_games", fake_many_games)
     df = tf.simulate_many_games(n_games=3, strategies=[], seed=0, n_jobs=1)
     assert set(df["winner"]) == {"P1", "P2"}
+
+
+@pytest.mark.parametrize(
+    "flag,val",
+    [
+        ("-n", "0"),
+        ("-n", "-1"),
+        ("-p", "0"),
+        ("-p", "-2"),
+        ("-j", "0"),
+        ("-j", "-3"),
+    ],
+)
+def test_cli_rejects_nonpositive_values(flag, val):
+    with pytest.raises(SystemExit):
+        tf.measure_sim_times(argv=[flag, val])
+
+
+def test_build_arg_parser_defaults():
+    parser = tf.build_arg_parser()
+    args = parser.parse_args([])
+    assert args.n_games == 1000 and isinstance(args.n_games, int)
+    assert args.players == 5 and isinstance(args.players, int)
+    assert args.seed == 42 and isinstance(args.seed, int)
+    assert args.jobs == 1 and isinstance(args.jobs, int)
+
+
+def test_winners_breakdown_multiple_winners(monkeypatch, capfd):
+    df = pd.DataFrame({"winner": ["P1", "P2", "P1"]})
+    monkeypatch.setattr(tf, "simulate_many_games", lambda **_: df)
+    tf.measure_sim_times(argv=[])  # defaults
+    out, _ = capfd.readouterr()
+    assert "P1" in out and "2" in out
+    assert "P2" in out and "1" in out
     


### PR DESCRIPTION
## Summary
- validate CLI arguments in time_farkle via new `build_arg_parser`
- ensure negative or zero CLI values trigger an error
- test defaults returned by the parser
- verify winners breakdown output when multiple winners occur

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c654bff04832fabc26b79cb78503d