### PR TITLE
Add postponed evaluation to type hints

### DIFF
--- a/src/farkle/types.py
+++ b/src/farkle/types.py
@@ -1,4 +1,5 @@
 # src/farkle/types.py  (new tiny helper, purely for typing)
+from __future__ import annotations
 from typing import Tuple, TypeAlias
 
 import numpy as np


### PR DESCRIPTION
## Summary
- enable postponed evaluation of annotations for compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c65603f5c832f99eafa851898ae57