### PR TITLE
Enforce matching keys in build_tiers

### DIFF
--- a/src/farkle/utils.py
+++ b/src/farkle/utils.py
@@ -9,6 +9,8 @@ import pandas as pd
 
 def build_tiers(mu: Dict[str, float], sigma: Dict[str, float], z: float = 2.326) -> Dict[str, int]:
     """Group strategies into overlapping confidence tiers."""
+    if set(mu.keys()) != set(sigma.keys()):
+        raise ValueError("mu and sigma must contain the same strategy keys")
     sorted_items = sorted(mu.items(), key=lambda kv: kv[1], reverse=True)
     tier_map: Dict[str, int] = {}
     if not sorted_items:

--- a/tests/unit/test_utils_functions.py
+++ b/tests/unit/test_utils_functions.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from farkle.utils import bh_correct, bonferroni_pairs, build_tiers
 
@@ -22,6 +23,13 @@ def test_build_tiers_multiple_tiers():
     assert tiers["A"] == 1
     assert tiers["B"] == 2
     assert tiers["C"] == 2
+
+
+def test_build_tiers_key_mismatch():
+    mu = {"A": 100.0}
+    sigma = {"A": 1.0, "B": 1.0}
+    with pytest.raises(ValueError):
+        build_tiers(mu, sigma)
 
 
 def test_bh_correct_typical():


### PR DESCRIPTION
## Summary
- validate that `build_tiers` receives the same keys for mu and sigma
- test error handling for mismatched dictionaries

## Testing
- `pytest tests/unit/test_utils_functions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c656e553c832fbf768407b6afdf80