### PR TITLE
Handle zero-pass case in bh_correct

### DIFF
--- a/src/farkle/utils.py
+++ b/src/farkle/utils.py
@@ -35,7 +35,10 @@ def bh_correct(pvals: np.ndarray, alpha: float = 0.02) -> np.ndarray:
     ranks = np.arange(1, len(pvals_array) + 1)
     critical_values = alpha * ranks / len(pvals_array)
     passed_mask = pvals_array[sorted_indices] <= critical_values
-    threshold = pvals_array[sorted_indices][passed_mask].max() if passed_mask.any() else 0.0
+    if not passed_mask.any():
+        return np.full_like(pvals_array, False, dtype=bool)
+
+    threshold = pvals_array[sorted_indices][passed_mask].max()
     return pvals_array <= threshold
 
 

--- a/tests/unit/test_utils_functions.py
+++ b/tests/unit/test_utils_functions.py
@@ -36,6 +36,12 @@ def test_bh_correct_none_pass():
     assert mask.tolist() == [False, False, False]
 
 
+def test_bh_correct_all_high_pvals():
+    pvals = np.array([0.9, 0.85, 0.95, 0.99])
+    mask = bh_correct(pvals, alpha=0.05)
+    assert mask.tolist() == [False, False, False, False]
+
+
 def test_bonferroni_pairs_basic_determinism():
     strats = ["S1", "S2", "S3"]
     df1 = bonferroni_pairs(strats, games_needed=2, seed=42)


### PR DESCRIPTION
## Summary
- avoid threshold computation in `bh_correct` when no p-values pass
- add a unit test covering all p-values failing BH

## Testing
- `pytest tests/unit/test_utils_functions.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c656ef7b8832fb5522528f36d17f1