### PR TITLE
Update bonferroni_pairs validation

### DIFF
--- a/src/farkle/utils.py
+++ b/src/farkle/utils.py
@@ -6,6 +6,9 @@ from typing import Dict, List
 import numpy as np
 import pandas as pd
 
+# Max unsigned 32-bit integer for random seed generation
+MAX_UINT32 = 2**32 - 1
+
 
 def build_tiers(mu: Dict[str, float], sigma: Dict[str, float], z: float = 2.326) -> Dict[str, int]:
     """Group strategies into overlapping confidence tiers."""
@@ -41,10 +44,13 @@ def bh_correct(pvals: np.ndarray, alpha: float = 0.02) -> np.ndarray:
 
 def bonferroni_pairs(strats: List[str], games_needed: int, seed: int) -> pd.DataFrame:
     """Generate a schedule for Bonferroni-corrected head-to-head games."""
+    if games_needed < 0:
+        raise ValueError("games_needed must be non-negative")
+
     random_generator = np.random.default_rng(seed)
     schedule_rows = []
     for strat_a, strat_b in itertools.combinations(strats, 2):
-        random_seeds = random_generator.integers(0, 2**32 - 1, size=games_needed)
+        random_seeds = random_generator.integers(0, MAX_UINT32, size=games_needed)
         for game_seed in random_seeds:
             schedule_rows.append({"a": strat_a, "b": strat_b, "seed": int(game_seed)})
     return pd.DataFrame(schedule_rows)

--- a/tests/unit/test_utils_functions.py
+++ b/tests/unit/test_utils_functions.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from farkle.utils import bh_correct, bonferroni_pairs, build_tiers
 
@@ -51,4 +52,13 @@ def test_bonferroni_pairs_basic_determinism():
 def test_bonferroni_pairs_not_enough_strats():
     assert bonferroni_pairs([], games_needed=2, seed=0).empty
     assert bonferroni_pairs(["A"], games_needed=2, seed=0).empty
-    
+
+
+def test_bonferroni_pairs_zero_games():
+    df = bonferroni_pairs(["A", "B"], games_needed=0, seed=1)
+    assert df.empty
+
+
+def test_bonferroni_pairs_negative_games():
+    with pytest.raises(ValueError):
+        bonferroni_pairs(["A", "B"], games_needed=-1, seed=1)


### PR DESCRIPTION
## Summary
- define `MAX_UINT32` constant in `utils`
- raise `ValueError` for negative `games_needed`
- use `MAX_UINT32` for seed generation
- extend utils tests for edge cases

## Testing
- `pytest tests/unit/test_utils_functions.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c657004a0832f9cefd57dd22e1c7f