### PR TITLE
Improve utils API docs and naming

### DIFF
--- a/src/farkle/utils.py
+++ b/src/farkle/utils.py
@@ -7,18 +7,48 @@ import numpy as np
 import pandas as pd
 
 
-def build_tiers(mu: Dict[str, float], sigma: Dict[str, float], z: float = 2.326) -> Dict[str, int]:
-    """Group strategies into overlapping confidence tiers."""
-    sorted_items = sorted(mu.items(), key=lambda kv: kv[1], reverse=True)
+def build_tiers(
+    means: Dict[str, float],
+    stdevs: Dict[str, float],
+    z: float = 2.326,
+) -> Dict[str, int]:
+    """Group strategies into overlapping confidence tiers.
+
+    Parameters
+    ----------
+    means:
+        Mapping from strategy name to estimated mean performance.
+    stdevs:
+        Mapping from strategy name to the corresponding standard deviation.
+    z:
+        Z-score for the desired confidence level, defaulting to 2.326 (approx.
+        99% one-sided).
+
+    Returns
+    -------
+    Dict[str, int]
+        Mapping from strategy name to a tier index starting at 1.
+
+    Edge Cases
+    ----------
+    If ``means`` is empty, the returned dictionary is empty.
+
+    Examples
+    --------
+    >>> build_tiers({'A': 100.0, 'B': 99.0}, {'A': 0.5, 'B': 0.5})
+    {'A': 1, 'B': 1}
+    """
+
+    sorted_items = sorted(means.items(), key=lambda kv: kv[1], reverse=True)
     tier_map: Dict[str, int] = {}
     if not sorted_items:
         return tier_map
     current_tier = 1
-    current_lower = mu[sorted_items[0][0]] - z * sigma[sorted_items[0][0]]
+    current_lower = means[sorted_items[0][0]] - z * stdevs[sorted_items[0][0]]
     tier_map[sorted_items[0][0]] = current_tier
     for name, _ in sorted_items[1:]:
-        lower_bound = mu[name] - z * sigma[name]
-        upper_bound = mu[name] + z * sigma[name]
+        lower_bound = means[name] - z * stdevs[name]
+        upper_bound = means[name] + z * stdevs[name]
         if upper_bound < current_lower:
             current_tier += 1
             current_lower = lower_bound
@@ -28,8 +58,31 @@ def build_tiers(mu: Dict[str, float], sigma: Dict[str, float], z: float = 2.326)
     return tier_map
 
 
-def bh_correct(pvals: np.ndarray, alpha: float = 0.02) -> np.ndarray:
-    """Return a boolean mask for Benjamini–Hochberg FDR control."""
+def benjamini_hochberg(pvals: np.ndarray, alpha: float = 0.02) -> np.ndarray:
+    """Apply the Benjamini–Hochberg FDR procedure.
+
+    Parameters
+    ----------
+    pvals:
+        Array of p-values to correct.
+    alpha:
+        Desired false discovery rate. Defaults to ``0.02``.
+
+    Returns
+    -------
+    np.ndarray
+        Boolean array indicating which hypotheses pass the FDR threshold.
+
+    Edge Cases
+    ----------
+    If ``pvals`` is empty, an empty boolean array is returned.
+
+    Examples
+    --------
+    >>> benjamini_hochberg(np.array([0.01, 0.02, 0.2]), alpha=0.05).tolist()
+    [True, True, False]
+    """
+
     pvals_array = np.asarray(pvals)
     sorted_indices = np.argsort(pvals_array)
     ranks = np.arange(1, len(pvals_array) + 1)
@@ -39,8 +92,40 @@ def bh_correct(pvals: np.ndarray, alpha: float = 0.02) -> np.ndarray:
     return pvals_array <= threshold
 
 
+def bh_correct(pvals: np.ndarray, alpha: float = 0.02) -> np.ndarray:
+    """Backward-compatible alias for :func:`benjamini_hochberg`."""
+    return benjamini_hochberg(pvals, alpha)
+
+
 def bonferroni_pairs(strats: List[str], games_needed: int, seed: int) -> pd.DataFrame:
-    """Generate a schedule for Bonferroni-corrected head-to-head games."""
+    """Generate a schedule for Bonferroni-corrected head-to-head games.
+
+    Parameters
+    ----------
+    strats:
+        List of strategy names.
+    games_needed:
+        Number of games to schedule per strategy pair.
+    seed:
+        Seed for the random number generator to ensure determinism.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Table with columns ``"a"``, ``"b"`` and ``"seed"`` describing the schedule.
+
+    Edge Cases
+    ----------
+    If fewer than two strategies are provided, an empty :class:`pandas.DataFrame`
+    is returned.
+
+    Examples
+    --------
+    >>> df = bonferroni_pairs(["S1", "S2"], games_needed=1, seed=0)
+    >>> df.shape[0]
+    1
+    """
+
     random_generator = np.random.default_rng(seed)
     schedule_rows = []
     for strat_a, strat_b in itertools.combinations(strats, 2):

--- a/tests/unit/test_utils_functions.py
+++ b/tests/unit/test_utils_functions.py
@@ -5,20 +5,20 @@ from farkle.utils import bh_correct, bonferroni_pairs, build_tiers
 
 
 def test_build_tiers_empty():
-    assert build_tiers({}, {}) == {}
+    assert build_tiers(means={}, stdevs={}) == {}
 
 
 def test_build_tiers_overlapping():
     mu = {"A": 100.0, "B": 99.0}
     sigma = {"A": 0.5, "B": 0.5}
-    tiers = build_tiers(mu, sigma, z=2)
+    tiers = build_tiers(means=mu, stdevs=sigma, z=2)
     assert tiers == {"A": 1, "B": 1}
 
 
 def test_build_tiers_multiple_tiers():
     mu = {"A": 100.0, "B": 95.0, "C": 93.0}
     sigma = {"A": 1.0, "B": 1.0, "C": 1.0}
-    tiers = build_tiers(mu, sigma, z=2)
+    tiers = build_tiers(means=mu, stdevs=sigma, z=2)
     assert tiers["A"] == 1
     assert tiers["B"] == 2
     assert tiers["C"] == 2
@@ -51,4 +51,3 @@ def test_bonferroni_pairs_basic_determinism():
 def test_bonferroni_pairs_not_enough_strats():
     assert bonferroni_pairs([], games_needed=2, seed=0).empty
     assert bonferroni_pairs(["A"], games_needed=2, seed=0).empty
-    


### PR DESCRIPTION
## Summary
- rename `mu` and `sigma` parameters to `means` and `stdevs` in `build_tiers`
- rename `bh_correct` to `benjamini_hochberg` and keep `bh_correct` alias
- document edge cases and parameters for `build_tiers`, `benjamini_hochberg` and `bonferroni_pairs`
- update call sites and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c65715b88832faf89e651449c8e2b