### PR TITLE
Fix strategy_yaml type error

### DIFF
--- a/src/farkle/watch_game.py
+++ b/src/farkle/watch_game.py
@@ -57,7 +57,8 @@ def strategy_yaml(s: ThresholdStrategy) -> str:
     """
     
     # dataclass → plain dict (keeps declared order)
-    assert isinstance(s, ThresholdStrategy)
+    if not isinstance(s, ThresholdStrategy):
+        raise TypeError("strategy_yaml expects a ThresholdStrategy")
     d = asdict(s)
     
     # YAML-friendly booleans (lowercase)


### PR DESCRIPTION
## Summary
- validate the type passed to `strategy_yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687c65841468832f9d6da33277899211