### PR TITLE
Fix watch_game imports

### DIFF
--- a/src/farkle/watch_game.py
+++ b/src/farkle/watch_game.py
@@ -22,9 +22,9 @@ from typing import Sequence
 
 import numpy as np
 
-from farkle.engine import FarkleGame, FarklePlayer  # :contentReference[oaicite:0]{index=0}
-from farkle.scoring import default_score  # :contentReference[oaicite:1]{index=1}
-from farkle.strategies import (  # :contentReference[oaicite:2]{index=2}
+from farkle.engine import FarkleGame, FarklePlayer
+from farkle.scoring import default_score
+from farkle.strategies import (
     ThresholdStrategy,
     random_threshold_strategy,
 )


### PR DESCRIPTION
## Summary
- drop leftover `contentReference` comments from `watch_game`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c65860758832fa9f9ea655b5acaf5