### PR TITLE
Use context manager for scoring patch

### DIFF
--- a/src/farkle/watch_game.py
+++ b/src/farkle/watch_game.py
@@ -14,6 +14,7 @@ No game-logic is duplicated - we only *wrap* the real engine.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import random
 from dataclasses import asdict
@@ -30,11 +31,7 @@ from farkle.strategies import (  # :contentReference[oaicite:2]{index=2}
 )
 
 # ── 1.  Plain-text logger ----------------------------------------------------
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(message)s",
-    handlers=[logging.StreamHandler()]
-)
+logging.basicConfig(level=logging.INFO, format="%(message)s", handlers=[logging.StreamHandler()])
 log = logging.getLogger("watch")
 
 
@@ -55,15 +52,15 @@ def strategy_yaml(s: ThresholdStrategy) -> str:
         run_up_score    : false
         prefer_score    : true
     """
-    
+
     # dataclass → plain dict (keeps declared order)
     assert isinstance(s, ThresholdStrategy)
     d = asdict(s)
-    
+
     # YAML-friendly booleans (lowercase)
-    def _fmt(v): 
+    def _fmt(v):
         return str(v).lower() if isinstance(v, bool) else v
-    
+
     lines = [f"{k:<15}: {_fmt(v)}" for k, v in d.items()]
     return "\n".join(lines)
 
@@ -85,23 +82,40 @@ def _trace_decide(s: ThresholdStrategy, label: str) -> None:
     s.decide = MethodType(traced_decide, s)  # type: ignore[attr-defined]
 
 
-def _patch_default_score() -> None:
-    """Wrap scoring.default_score so every call is printed once."""
+@contextlib.contextmanager
+def patch_scoring():
+    """Temporarily wrap ``scoring.default_score`` so each call is logged."""
+
     global default_score  # module alias
-    original = default_score
+    import farkle.scoring as _scoring_mod
+
+    orig_local = default_score
+    orig_mod = _scoring_mod.default_score
 
     def traced_default_score(*args, **kw):
-        res = original(*args, **kw)  # type: ignore[arg-type]
+        res = orig_mod(*args, **kw)  # type: ignore[arg-type]
         pts, used, reroll = res[:3]
         roll = args[0]
         log.info(f"score({roll}) -> pts={pts:<4} used={used} reroll={reroll}")
         return res
 
-    # monkey-patch in the *farkle.scoring* module too
-    import farkle.scoring as _scoring_mod
-    
-    _scoring_mod.default_score = traced_default_score         # type: ignore[assignment]
-    default_score = traced_default_score                      # local alias
+    _scoring_mod.default_score = traced_default_score  # type: ignore[assignment]
+    default_score = traced_default_score
+    try:
+        yield
+    finally:
+        _scoring_mod.default_score = orig_mod  # type: ignore[assignment]
+        default_score = orig_local
+
+
+def _patch_default_score() -> None:
+    """Backward compatible wrapper for tests."""
+
+    cm = patch_scoring()
+    context = cm.__enter__()
+    # store context manager object so tests can manually exit if needed
+    _patch_default_score._cm = cm  # type: ignore[attr-defined]
+    return context
 
 
 class TracePlayer(FarklePlayer):
@@ -132,21 +146,16 @@ def watch_game(seed: int | None = None) -> None:
     _trace_decide(s2, "P2")
 
     # monkey-patch the *scoring* layer so we can see Smart-discard results
-    _patch_default_score()
+    with patch_scoring():
+        # --- wrap players so we can see every dice throw --------------------
+        p1 = TracePlayer("P1", s1, rng=np.random.default_rng(rng.integers(2**32)))
+        p2 = TracePlayer("P2", s2, rng=np.random.default_rng(rng.integers(2**32)))
 
-    # --- wrap players so we can see every dice throw --------------------
-    p1 = TracePlayer("P1", s1, rng=np.random.default_rng(rng.integers(2**32)))
-    p2 = TracePlayer("P2", s2, rng=np.random.default_rng(rng.integers(2**32)))
-
-    game = FarkleGame([p1, p2], target_score=10_000)
-    gm = game.play()
+        game = FarkleGame([p1, p2], target_score=10_000)
+        gm = game.play()
 
     log.info("\n===== final result =====")
-    log.info(
-        f"Winner: {gm.winner}  "
-        f"score={gm.winning_score}  "
-        f"rounds={gm.n_rounds}"
-    )
+    log.info(f"Winner: {gm.winner}  " f"score={gm.winning_score}  " f"rounds={gm.n_rounds}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement `patch_scoring` contextmanager for temporarily patching `default_score`
- apply the new context manager in `watch_game` and keep `_patch_default_score` for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c7f6580a4832fa875050e76db9e9c