### PR TITLE
Fix comments and add version constant

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -8,6 +8,8 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _v
 from pathlib import Path
 
+NO_PKG_MSG = "__package__ not detected, loading version from pyproject.toml"
+
 # Re-export the "friendly" surface
 from farkle.engine import FarklePlayer, GameMetrics
 from farkle.farkle_io import simulate_many_games_stream
@@ -17,11 +19,11 @@ from farkle.strategies import ThresholdStrategy
 
 # --------------------------------------------------------------------------- #
 # Robust Windows delete helper
-# OneDrive (and occasionally AV software) can momentarily keep a handle on
-# freshly-written files, making a plain Path.unlink() raise PermissionError.
+# OneDrive/AV software may hold a handle on newly written files,
+# making Path.unlink() raise PermissionError.
 # The test-suite calls unlink() many times and assumes it will *never* fail.
-# We monkey-patch pathlib.Path.unlink once, at import-time, so that ONLY
-# PermissionError is suppressed; all other OSErrors still propagate.
+# We patch pathlib.Path.unlink at import time so ONLY PermissionError is
+# suppressed; other OSErrors still propagate.
 # --------------------------------------------------------------------------- #
 
 _orig_unlink = pathlib.Path.unlink
@@ -56,14 +58,14 @@ def _read_version_from_toml() -> str:
     str
         Version string from pyproject.toml.
     """
-    toml_path = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+    toml_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
     with toml_path.open("rb") as fh:
         data = tomllib.load(fh)
     return data["project"]["version"]
 
 
 try:
-    assert __package__ is not None, "__package__ not detected, loading version from pyproject.toml"
+    assert __package__ is not None, NO_PKG_MSG
     __version__ = _v(__package__)  # importlib.metadata
 except PackageNotFoundError:
     __version__ = _read_version_from_toml()


### PR DESCRIPTION
## Summary
- shorten Windows unlink helper comments
- keep the `__package__` assert message in `NO_PKG_MSG`
- trim path building line to 79 chars or fewer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c7f6ddf14832f81c6ad5983ff3d47