### PR TITLE
Introduce pyproject constant

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -7,6 +7,9 @@ import tomllib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _v
 from pathlib import Path
+# Path to the project's pyproject.toml for local version fallback
+PYPROJECT_TOML = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+
 
 # Re-export the "friendly" surface
 from farkle.engine import FarklePlayer, GameMetrics
@@ -56,8 +59,7 @@ def _read_version_from_toml() -> str:
     str
         Version string from pyproject.toml.
     """
-    toml_path = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
-    with toml_path.open("rb") as fh:
+    with PYPROJECT_TOML.open("rb") as fh:
         data = tomllib.load(fh)
     return data["project"]["version"]
 


### PR DESCRIPTION
## Summary
- set `PYPROJECT_TOML` at module load time
- use this constant when reading fallback version

## Testing
- `pytest tests/unit/test_init.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c7f6e2e44832fa0a02977c456054a