### PR TITLE
Add comment for __all__ re-exports

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -36,6 +36,7 @@ def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False):
 # Patch globally (harmless on POSIX; vital on Windows)
 pathlib.Path.unlink = _safe_unlink  # type: ignore[assignment]
 
+# The following identifiers are re-exported for user convenience
 __all__ = [
     "FarklePlayer",
     "GameMetrics",


### PR DESCRIPTION
## Summary
- clarify re-export rationale in `src/farkle/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c7f7118a8832f8c269a55d710e0f1