### PR TITLE
Add module docstring to __main__

### DIFF
--- a/src/farkle/__main__.py
+++ b/src/farkle/__main__.py
@@ -1,5 +1,9 @@
+"""Entry point for `python -m farkle`.
+
+Simply calls `farkle.farkle_cli.main()` to run the command-line interface.
+"""
+
 from farkle.farkle_cli import main
 
 if __name__ == "__main__":
     main()
-    


### PR DESCRIPTION
## Summary
- document entry point in `src/farkle/__main__.py`

## Testing
- `ruff check src/farkle/__main__.py`
- `black src/farkle/__main__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c7f777e18832fa4a3b14de0bf30ea