### PR TITLE
Fix final round metrics and unlink indentation

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -56,12 +56,12 @@ def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False):
     re-raised.
     """
     with contextlib.suppress(PermissionError):
-    try:
-        return _orig_unlink(self, missing_ok=missing_ok)
-    except PermissionError as e:
-        if getattr(e, "winerror", None) == 32:
-            return None
-        raise
+        try:
+            return _orig_unlink(self, missing_ok=missing_ok)
+        except PermissionError as e:
+            if getattr(e, "winerror", None) == 32:
+                return None
+            raise
 
 
 # Patch globally (harmless on POSIX; vital on Windows)

--- a/src/farkle/engine.py
+++ b/src/farkle/engine.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Sequence
 import numpy as np
 
 from farkle.scoring import DiceRoll, default_score
-from farkle.strategies import PreferScore, ThresholdStrategy
+from farkle.strategies import ThresholdStrategy
 
 """engine.py
 ============
@@ -404,8 +404,8 @@ class FarkleGame:
             for player in self.players:
                 player.take_turn(
                     self.target_score,  # This is that vestigial stat
-                    final_round = final_round,
-                    score_to_beat = score_to_beat,
+                    final_round=final_round,
+                    score_to_beat=score_to_beat,
                 )
                 # First trigger starts the final round
                 if not final_round and player.score >= self.target_score:
@@ -420,7 +420,7 @@ class FarkleGame:
 
         sorted_players = sorted(self.players, key=lambda pl: pl.score, reverse=True)
         winner = sorted_players[0]
-        runner = sorted_players[1] if len(sorted_pl) > 1 else None
+        runner = sorted_players[1] if len(sorted_players) > 1 else None
         ranks = {player.name: rk for rk, player in enumerate(sorted_players, start=1)}
         
         players_block: Dict[str, PlayerStats] = {}


### PR DESCRIPTION
## Summary
- remove unused PreferScore import
- patch score-to-beat handling in `FarkleGame.play`
- clean up keyword spacing in `player.take_turn` call
- repair `_safe_unlink` indentation

## Testing
- `python -m py_compile src/farkle/engine.py`
- `python -m py_compile src/farkle/__init__.py`
- `pytest tests/unit/test_engine.py -q` *(fails: ModuleNotFoundError: yaml, numba)*

------
https://chatgpt.com/codex/tasks/task_e_687e22c9fe34832fbbe312d8c8d6aaac