### PR TITLE
Fix run_full_field imports and update helper functions

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -6,12 +6,12 @@ At import time :class:`pathlib.Path.unlink` is monkey patched with a helper that
 safely suppresses transient ``PermissionError`` on Windows.
 """
 
-import contextlib
 import pathlib
 import tomllib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _v
 from pathlib import Path
+
 # Path to the project's pyproject.toml for local version fallback
 PYPROJECT_TOML = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
 
@@ -19,11 +19,11 @@ PYPROJECT_TOML = Path(__file__).resolve().parent.parent.parent / "pyproject.toml
 NO_PKG_MSG = "__package__ not detected, loading version from pyproject.toml"
 
 # Re-export the "friendly" surface
-from farkle.engine import FarklePlayer, GameMetrics
-from farkle.farkle_io import simulate_many_games_stream
-from farkle.simulation import generate_strategy_grid, simulate_many_games_from_seeds
-from farkle.stats import games_for_power
-from farkle.strategies import PreferScore, ThresholdStrategy
+from farkle.engine import FarklePlayer, GameMetrics  # noqa: E402
+from farkle.farkle_io import simulate_many_games_stream  # noqa: E402
+from farkle.simulation import generate_strategy_grid, simulate_many_games_from_seeds  # noqa: E402
+from farkle.stats import games_for_power  # noqa: E402
+from farkle.strategies import PreferScore, ThresholdStrategy  # noqa: E402
 
 # --------------------------------------------------------------------------- #
 # Robust Windows delete helper
@@ -37,9 +37,8 @@ from farkle.strategies import PreferScore, ThresholdStrategy
 _orig_unlink = pathlib.Path.unlink
 
 
-def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False):
-    """Wrapper around Path.unlink that squashes the WinError 32 race.
-    Deletes ``self`` while ignoring transient permission issues.
+def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False) -> None:
+    """Safely unlink ``self`` while ignoring transient permission issues.
 
     Parameters
     ----------
@@ -55,7 +54,6 @@ def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False):
     Only ``PermissionError`` is suppressed. Any other :class:`OSError` will be
     re-raised.
     """
-    with contextlib.suppress(PermissionError):
     try:
         return _orig_unlink(self, missing_ok=missing_ok)
     except PermissionError as e:

--- a/src/farkle/run_full_field.py
+++ b/src/farkle/run_full_field.py
@@ -6,6 +6,7 @@ run_full_field.py  -  Phase-1 full-grid screen for all table sizes
    • Detectable lift Δ   = 0.03     (3-percentage-point edge)
 """
 
+import importlib
 import multiprocessing as mp
 import shutil
 from math import ceil
@@ -16,19 +17,19 @@ import pandas as pd
 from scipy.stats import norm
 
 
-def _concat_row_shards(out_dir: Path, n: int) -> None:
+def _concat_row_shards(out_dir: Path, n_players: int) -> None:
     """Combine row shard files and remove the temporary directory.
 
     If no shard files are found the function simply returns without
     writing anything. Reading/writing parquet requires ``pyarrow`` to be
     installed.
     """
-    row_dir = out_dir / f"{n}p_rows"
+    row_dir = out_dir / f"{n_players}p_rows"
     files = sorted(row_dir.glob("*.parquet"))
     if not files:
         return
     df = pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
-    df.to_parquet(out_dir / f"{n}p_rows.parquet")
+    df.to_parquet(out_dir / f"{n_players}p_rows.parquet")
     shutil.rmtree(row_dir, ignore_errors=True)
 
 

--- a/src/farkle/run_tournament.py
+++ b/src/farkle/run_tournament.py
@@ -54,6 +54,7 @@ class TournamentConfig:
     def games_per_shuffle(self) -> int:
         return 8_160 // self.n_players
 
+
 # metric fields tracked per winning strategy
 METRIC_LABELS: Tuple[str, ...] = (
     "winning_score",
@@ -105,14 +106,14 @@ def _init_worker(
         Strategy objects to copy into the worker.
     config: TournamentConfig
         Config rules sent with worker.
-        
+
     Returns
     -------
     None
     """
 
     global _STRATS, _CFG, N_PLAYERS, GAMES_PER_SHUFFLE
-    if 8_160 % n_players != 0:
+    if 8_160 % config.n_players != 0:
         raise ValueError("n_players must divide 8,160")
     _STRATS = list(strategies)
     _CFG = config
@@ -305,10 +306,9 @@ def run_tournament(
     n_jobs: int | None = None,
     collect_metrics: bool = False,
     row_output_directory: Path | None = None,  # None if --row-dir omitted
-    num_shuffles: int = NUM_SHUFFLES,
+    num_shuffles: int = NUM_SHUFFLES,  # noqa: ARG001
 ) -> None:
-        """
-    Orchestrate a multi-process Monte-Carlo Farkle tournament.
+    """Orchestrate a multi-process Monte-Carlo Farkle tournament.
 
     Parameters
     ----------

--- a/src/farkle/scoring_lookup.py
+++ b/src/farkle/scoring_lookup.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from itertools import combinations_with_replacement
-from typing import Sequence
+from typing import Sequence, Tuple
 
 import numba as nb
 import numpy as np
@@ -83,7 +83,7 @@ def _four_kind_plus_pair(ctr: Int64Array1D) -> Tuple[int, int]:
 
 
 @nb.njit(cache=True)
-def _apply_sets(ctr: Int64Arr1D) -> tuple[int, int]:
+def _apply_sets(ctr: Int64Array1D) -> tuple[int, int]:
     """Score and consume any n-of-a-kind groups.
 
     Parameters
@@ -180,7 +180,7 @@ def _evaluate_nb(
 @lru_cache(maxsize=4096)
 def evaluate(counts: SixFaceCounts) -> tuple[int, int, int, int]:
     """Score a counts tuple via the JIT compiled core.
-    
+
     The function is intentionally defensive – invalid input should raise a
     :class:`ValueError` rather than yielding nonsensical results.
 
@@ -193,14 +193,14 @@ def evaluate(counts: SixFaceCounts) -> tuple[int, int, int, int]:
         (score, used, single_fives, single_ones) in the same format as
         :func:`_evaluate_nb`.
     """
-if len(counts) != 6:
-    raise ValueError("counts must contain exactly six values")
-if not all(isinstance(c, int) for c in counts):
-    raise TypeError(f"non-integers in {counts!r}")
-if any(c < 0 for c in counts):
-    raise ValueError(f"negative count in {counts!r}")
-if sum(counts) > 6:
-    raise ValueError(f"more than six dice specified: {counts!r}")
+    if len(counts) != 6:
+        raise ValueError("counts must contain exactly six values")
+    if not all(isinstance(c, int) for c in counts):
+        raise TypeError(f"non-integers in {counts!r}")
+    if any(c < 0 for c in counts):
+        raise ValueError(f"negative count in {counts!r}")
+    if sum(counts) > 6:
+        raise ValueError(f"more than six dice specified: {counts!r}")
     return _evaluate_nb(*counts)
 
 

--- a/src/farkle/types.py
+++ b/src/farkle/types.py
@@ -1,11 +1,11 @@
-from __future__ import annotations
-=======
 """Shared type aliases for the Farkle project.
 
 This module centralizes a few simple ``TypeAlias`` definitions used across
 the code base.  ``Int64Array1D`` is provided as a convenience for NumPy arrays
 of ``np.int64`` that are expected, by convention, to be one-dimensional.
 """
+
+from __future__ import annotations
 
 from typing import Tuple, TypeAlias
 


### PR DESCRIPTION
## Summary
- import `importlib` for `run_full_field`
- clean up `_safe_unlink` helper
- validate player count in `_init_worker`
- fix indentation in scoring helpers
- tidy type alias module

## Testing
- `ruff check src/farkle/run_full_field.py src/farkle/run_tournament.py src/farkle/__init__.py src/farkle/scoring_lookup.py src/farkle/types.py --fix`
- `black src/farkle/run_full_field.py src/farkle/run_tournament.py src/farkle/__init__.py src/farkle/scoring_lookup.py src/farkle/types.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib', 'sklearn', 'trueskill')*

------
https://chatgpt.com/codex/tasks/task_e_687e22ee86b4832f98264c864ca29384