### PR TITLE
Fix run_rf output usage and add tests

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -12,18 +12,17 @@ import tomllib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _v
 from pathlib import Path
-# Path to the project's pyproject.toml for local version fallback
-PYPROJECT_TOML = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
 
-
-NO_PKG_MSG = "__package__ not detected, loading version from pyproject.toml"
-
-# Re-export the "friendly" surface
 from farkle.engine import FarklePlayer, GameMetrics
 from farkle.farkle_io import simulate_many_games_stream
 from farkle.simulation import generate_strategy_grid, simulate_many_games_from_seeds
 from farkle.stats import games_for_power
 from farkle.strategies import PreferScore, ThresholdStrategy
+
+# Path to the project's pyproject.toml for local version fallback
+PYPROJECT_TOML = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+
+NO_PKG_MSG = "__package__ not detected, loading version from pyproject.toml"
 
 # --------------------------------------------------------------------------- #
 # Robust Windows delete helper
@@ -56,12 +55,12 @@ def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False):
     re-raised.
     """
     with contextlib.suppress(PermissionError):
-    try:
-        return _orig_unlink(self, missing_ok=missing_ok)
-    except PermissionError as e:
-        if getattr(e, "winerror", None) == 32:
-            return None
-        raise
+        try:
+            return _orig_unlink(self, missing_ok=missing_ok)
+        except PermissionError as e:
+            if getattr(e, "winerror", None) == 32:
+                return None
+            raise
 
 
 # Patch globally (harmless on POSIX; vital on Windows)

--- a/tests/unit/test_run_rf_functionality.py
+++ b/tests/unit/test_run_rf_functionality.py
@@ -1,0 +1,50 @@
+import os
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from farkle import run_rf, run_trueskill
+
+
+def _setup_data(tmp_path: Path) -> Path:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    metrics = pd.DataFrame({"strategy": ["A"], "feat": [1]})
+    metrics.to_parquet(data_dir / "metrics.parquet")
+    ratings = {"A": run_trueskill.RatingStats(0.0, 1.0)}
+    with open(data_dir / "ratings_pooled.pkl", "wb") as fh:
+        pickle.dump(ratings, fh)
+    return data_dir
+
+
+def test_run_rf_custom_output_path(tmp_path):
+    data_dir = _setup_data(tmp_path)
+    out_file = data_dir / "custom.json"
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        run_rf.run_rf(output_path=out_file)
+    finally:
+        os.chdir(cwd)
+    assert out_file.exists()
+    assert not (data_dir / "rf_importance.json").exists()
+
+
+def test_run_rf_importance_length_check(tmp_path, monkeypatch):
+    data_dir = _setup_data(tmp_path)
+
+    def fake_perm_importance(_model, _X, _y, n_repeats=5, random_state=None):
+        _ = n_repeats, random_state
+        return {"importances_mean": np.array([0.1, 0.2])}
+
+    monkeypatch.setattr(run_rf, "permutation_importance", fake_perm_importance)
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        with pytest.raises(ValueError, match="Mismatch between number of features"):
+            run_rf.run_rf(output_path=data_dir / "out.json")
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- fix bug in run_rf output_path handling
- clarify variable names and update documentation
- resolve indentation in `_safe_unlink`
- add unit tests for run_rf functionality

## Testing
- `ruff check src/farkle/run_rf.py tests/unit/test_run_rf_functionality.py`
- `black src/farkle/run_rf.py`
- `black tests/unit/test_run_rf_functionality.py`
- `ruff check src/farkle/__init__.py`
- `black src/farkle/__init__.py`
- `pytest -q tests/unit/test_run_rf_functionality.py tests/unit/test_run_rf_helpers.py` *(fails: ModuleNotFoundError: numba, SyntaxError in scoring_lookup.py)*

------
https://chatgpt.com/codex/tasks/task_e_687e22f6624c832fb5d0f7f3735a1f53