### PR TITLE
Fix worker config bug and test coverage

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -12,6 +12,7 @@ import tomllib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _v
 from pathlib import Path
+
 # Path to the project's pyproject.toml for local version fallback
 PYPROJECT_TOML = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
 
@@ -56,12 +57,12 @@ def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False):
     re-raised.
     """
     with contextlib.suppress(PermissionError):
-    try:
-        return _orig_unlink(self, missing_ok=missing_ok)
-    except PermissionError as e:
-        if getattr(e, "winerror", None) == 32:
-            return None
-        raise
+        try:
+            return _orig_unlink(self, missing_ok=missing_ok)
+        except PermissionError as e:
+            if getattr(e, "winerror", None) == 32:
+                return None
+            raise
 
 
 # Patch globally (harmless on POSIX; vital on Windows)


### PR DESCRIPTION
## Summary
- ensure `_init_worker` uses config player count
- respect `num_shuffles` arg in `run_tournament`
- fix `_safe_unlink` indentation
- update tournament tests for new API and add coverage for shuffle override

## Testing
- `ruff format src/farkle/run_tournament.py tests/unit/test_run_tournament.py src/farkle/__init__.py`
- `ruff check --fix src/farkle/run_tournament.py tests/unit/test_run_tournament.py src/farkle/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError for numba and SyntaxError in scoring_lookup)*

------
https://chatgpt.com/codex/tasks/task_e_687e23059c0c832f876a34c621cc369b