### PR TITLE
Fix scoring lookup evaluator & cleanup type aliases

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -12,6 +12,7 @@ import tomllib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _v
 from pathlib import Path
+
 # Path to the project's pyproject.toml for local version fallback
 PYPROJECT_TOML = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
 
@@ -38,7 +39,8 @@ _orig_unlink = pathlib.Path.unlink
 
 
 def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False):
-    """Wrapper around Path.unlink that squashes the WinError 32 race.
+    """Wrapper around ``Path.unlink`` that squashes the WinError 32 race.
+
     Deletes ``self`` while ignoring transient permission issues.
 
     Parameters
@@ -56,12 +58,12 @@ def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False):
     re-raised.
     """
     with contextlib.suppress(PermissionError):
-    try:
-        return _orig_unlink(self, missing_ok=missing_ok)
-    except PermissionError as e:
-        if getattr(e, "winerror", None) == 32:
-            return None
-        raise
+        try:
+            return _orig_unlink(self, missing_ok=missing_ok)
+        except PermissionError as e:
+            if getattr(e, "winerror", None) == 32:
+                return None
+            raise
 
 
 # Patch globally (harmless on POSIX; vital on Windows)

--- a/src/farkle/scoring_lookup.py
+++ b/src/farkle/scoring_lookup.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from itertools import combinations_with_replacement
-from typing import Sequence
+from typing import Sequence, Tuple
 
 import numba as nb
 import numpy as np
@@ -83,7 +83,7 @@ def _four_kind_plus_pair(ctr: Int64Array1D) -> Tuple[int, int]:
 
 
 @nb.njit(cache=True)
-def _apply_sets(ctr: Int64Arr1D) -> tuple[int, int]:
+def _apply_sets(ctr: Int64Array1D) -> tuple[int, int]:
     """Score and consume any n-of-a-kind groups.
 
     Parameters
@@ -180,7 +180,7 @@ def _evaluate_nb(
 @lru_cache(maxsize=4096)
 def evaluate(counts: SixFaceCounts) -> tuple[int, int, int, int]:
     """Score a counts tuple via the JIT compiled core.
-    
+
     The function is intentionally defensive – invalid input should raise a
     :class:`ValueError` rather than yielding nonsensical results.
 
@@ -193,14 +193,14 @@ def evaluate(counts: SixFaceCounts) -> tuple[int, int, int, int]:
         (score, used, single_fives, single_ones) in the same format as
         :func:`_evaluate_nb`.
     """
-if len(counts) != 6:
-    raise ValueError("counts must contain exactly six values")
-if not all(isinstance(c, int) for c in counts):
-    raise TypeError(f"non-integers in {counts!r}")
-if any(c < 0 for c in counts):
-    raise ValueError(f"negative count in {counts!r}")
-if sum(counts) > 6:
-    raise ValueError(f"more than six dice specified: {counts!r}")
+    if len(counts) != 6:
+        raise ValueError("counts must contain exactly six values")
+    if not all(isinstance(c, int) for c in counts):
+        raise TypeError(f"non-integers in {counts!r}")
+    if any(c < 0 for c in counts):
+        raise ValueError(f"negative count in {counts!r}")
+    if sum(counts) > 6:
+        raise ValueError(f"more than six dice specified: {counts!r}")
     return _evaluate_nb(*counts)
 
 

--- a/src/farkle/types.py
+++ b/src/farkle/types.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-=======
+
 """Shared type aliases for the Farkle project.
 
 This module centralizes a few simple ``TypeAlias`` definitions used across


### PR DESCRIPTION
## Summary
- repair indentation in `evaluate` and restore validation logic
- fix `_apply_sets` type annotation
- update `_safe_unlink` helper formatting
- remove stray merge line in `types.py`
- ensure formatting with black

## Testing
- `pytest tests/unit/test_scoring_lookup_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687e231bc1d0832f911794eb9dd5f2e3