### PR TITLE
Fix simulation grid name and docs

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -2,26 +2,22 @@
 
 Note
 ----
-At import time :class:`pathlib.Path.unlink` is monkey patched with a helper that
-safely suppresses transient ``PermissionError`` on Windows.
+At import time :class:`pathlib.Path.unlink` is monkey patched with a helper
+that safely suppresses transient ``PermissionError`` on Windows.
 """
 
-import contextlib
 import pathlib
 import tomllib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _v
 from pathlib import Path
-# Path to the project's pyproject.toml for local version fallback
-PYPROJECT_TOML = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
 
-
-NO_PKG_MSG = "__package__ not detected, loading version from pyproject.toml"
 
 # Re-export the "friendly" surface
 from farkle.engine import FarklePlayer, GameMetrics
 from farkle.farkle_io import simulate_many_games_stream
-from farkle.simulation import generate_strategy_grid, simulate_many_games_from_seeds
+from farkle.simulation import generate_strategy_grid
+from farkle.simulation import simulate_many_games_from_seeds
 from farkle.stats import games_for_power
 from farkle.strategies import PreferScore, ThresholdStrategy
 
@@ -55,7 +51,6 @@ def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False):
     Only ``PermissionError`` is suppressed. Any other :class:`OSError` will be
     re-raised.
     """
-    with contextlib.suppress(PermissionError):
     try:
         return _orig_unlink(self, missing_ok=missing_ok)
     except PermissionError as e:
@@ -78,6 +73,14 @@ __all__ = [
     "simulate_many_games_from_seeds",
     "games_for_power",
 ]
+
+# Diagnostic message for fallback version retrieval
+NO_PKG_MSG = "__package__ not detected, loading version from pyproject.toml"
+
+# Path to the project's pyproject.toml for local version fallback
+PYPROJECT_TOML = (
+    Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+)
 
 
 def _read_version_from_toml() -> str:

--- a/src/farkle/simulation.py
+++ b/src/farkle/simulation.py
@@ -55,7 +55,8 @@ def generate_strategy_grid(
     Parameters
     ----------
     score_thresholds, dice_thresholds, smart_five_opts, smart_one_opts,
-    consider_score_opts, consider_dice_opts, auto_hot_opts, run_up_score_opts
+    consider_score_opts, consider_dice_opts,
+    auto_hot_dice_opts, run_up_score_opts
         Sequences of options for the corresponding ``ThresholdStrategy``
         fields. ``None`` selects sensible defaults for each parameter.
 
@@ -75,7 +76,9 @@ def generate_strategy_grid(
         smart_five_opts = [True, False]
     if smart_one_opts is None:
         smart_one_opts = [True, False]
-    combos: List[Tuple[int, int, bool, bool, bool, bool, bool, bool, bool, bool]] = []
+    combos: List[
+        Tuple[int, int, bool, bool, bool, bool, bool, bool, bool, bool]
+    ] = []
 
     # Iterate over the basic option grid using itertools.product and filter
     for st, dt, sf, so, cs, cd, hd, rs in itertools.product(
@@ -85,7 +88,7 @@ def generate_strategy_grid(
         smart_one_opts,
         consider_score_opts,
         consider_dice_opts,
-        auto_hot_opts,
+        auto_hot_dice_opts,
         run_up_score_opts,
     ):
         # Can't be smart one without smart five
@@ -195,7 +198,9 @@ def experiment_size(
         return rb_choices * ps_choices
 
     pair_count = sum(
-        _pair_variations(cs, cd) for cs in consider_score_opts for cd in consider_dice_opts
+        _pair_variations(cs, cd)
+        for cs in consider_score_opts
+        for cd in consider_dice_opts
     )
 
     return base * pair_count
@@ -264,7 +269,8 @@ def _play_game(
     winners = [name for name, ps in gm.players.items() if ps.rank == 1]
     if len(winners) != 1:
         raise ValueError(
-            f"Expected exactly one player with rank == 1, got {len(winners)}: {winners}"
+            "Expected exactly one player with rank == 1, "
+            f"got {len(winners)}: {winners}"
         )
     # Determine the winner from the PlayerStats block
     winner = next(name for name, ps in gm.players.items() if ps.rank == 1)


### PR DESCRIPTION
## Summary
- rename `auto_hot_opts` references in `generate_strategy_grid`
- tweak `_pair_variations` and winner check in `_play_game`
- repair `_safe_unlink` indentation

## Testing
- `flake8 src/farkle/simulation.py src/farkle/__init__.py`
- `pytest -q tests/unit/test_simulation.py::test_default_grid_size` *(fails: SyntaxError in scoring_lookup.py)*

------
https://chatgpt.com/codex/tasks/task_e_687e232313b0832f83c41e70dd52b143