### PR TITLE
Fix CLI entry and add test coverage

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -12,6 +12,7 @@ import tomllib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _v
 from pathlib import Path
+
 # Path to the project's pyproject.toml for local version fallback
 PYPROJECT_TOML = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
 
@@ -56,12 +57,12 @@ def _safe_unlink(self: pathlib.Path, *, missing_ok: bool = False):
     re-raised.
     """
     with contextlib.suppress(PermissionError):
-    try:
-        return _orig_unlink(self, missing_ok=missing_ok)
-    except PermissionError as e:
-        if getattr(e, "winerror", None) == 32:
-            return None
-        raise
+        try:
+            return _orig_unlink(self, missing_ok=missing_ok)
+        except PermissionError as e:
+            if getattr(e, "winerror", None) == 32:
+                return None
+            raise
 
 
 # Patch globally (harmless on POSIX; vital on Windows)

--- a/src/farkle/__main__.py
+++ b/src/farkle/__main__.py
@@ -1,9 +1,19 @@
-"""Entry point for `python -m farkle`.
+"""Command line entry point for the :mod:`farkle` package.
 
-Simply calls `farkle.farkle_cli.main()` to run the command-line interface.
+When executed as ``python -m farkle`` this module simply delegates to
+:func:`farkle.farkle_cli.main` which implements the full CLI logic.
 """
 
-from farkle.farkle_cli import main
+from __future__ import annotations
 
-if __name__ == "__main__":
+from farkle.farkle_cli import main as cli_main
+
+
+def main() -> None:
+    """Invoke :func:`farkle.farkle_cli.main`."""
+
+    cli_main()
+
+
+if __name__ == "__main__":  # pragma: no cover - direct execution path
     main()

--- a/tests/unit/test_main_module.py
+++ b/tests/unit/test_main_module.py
@@ -1,0 +1,14 @@
+import runpy
+
+
+def test_main_module_calls_cli(monkeypatch):
+    called = False
+
+    def fake_main():
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("farkle.farkle_cli.main", fake_main)
+    runpy.run_module("farkle", run_name="__main__")
+
+    assert called


### PR DESCRIPTION
## Summary
- update CLI entry module with clearer API
- repair `_safe_unlink` indentation
- add test ensuring `python -m farkle` invokes the CLI

## Testing
- `pytest tests/unit/test_main_module.py -q` *(fails: SyntaxError in scoring_lookup.py)*

------
https://chatgpt.com/codex/tasks/task_e_687e23631880832fb8ec26002978f9ba