### PR TITLE
Deduplicate version constants

### DIFF
--- a/src/farkle/__init__.py
+++ b/src/farkle/__init__.py
@@ -24,6 +24,7 @@ from farkle.strategies import FavorDiceOrScore, ThresholdStrategy  # noqa: E402
 # Path to the project's pyproject.toml for local version fallback
 PYPROJECT_TOML = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
 
+# Diagnostic message for fallback version retrieval
 NO_PKG_MSG = "__package__ not detected, loading version from pyproject.toml"
 
 # --------------------------------------------------------------------------- #
@@ -79,14 +80,6 @@ __all__ = [
     "simulate_many_games_from_seeds",
     "games_for_power",
 ]
-
-# Diagnostic message for fallback version retrieval
-NO_PKG_MSG = "__package__ not detected, loading version from pyproject.toml"
-
-# Path to the project's pyproject.toml for local version fallback
-PYPROJECT_TOML = (
-    Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
-)
 
 
 def _read_version_from_toml() -> str:


### PR DESCRIPTION
## Summary
- consolidate `PYPROJECT_TOML` and `NO_PKG_MSG` definitions
- format `src/farkle/__init__.py` with ruff/black

## Testing
- `ruff check src/farkle/__init__.py`
- `black src/farkle/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: hypothesis, matplotlib, sklearn, trueskill)*

------
https://chatgpt.com/codex/tasks/task_e_68804868e630832fbe55e327955c8385