### PR TITLE
Fix indentation in FarklePlayer._should_continue

### DIFF
--- a/src/farkle/engine.py
+++ b/src/farkle/engine.py
@@ -137,7 +137,7 @@ class FarklePlayer:
         score_needed = max(0, target_score - running_total)
 
         if final_round and running_total > score_to_beat and not self.strategy.run_up_score:
-                return False
+            return False
 
         keep_rolling = self.strategy.decide(
             turn_score=turn_score,


### PR DESCRIPTION
## Summary
- fix indentation for the `return False` line in FarklePlayer

## Testing
- `ruff check src/farkle/engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688048744c94832fa966a0567b7b9be6