### PR TITLE
Fix ruff import order in tests

### DIFF
--- a/tests/unit/test_run_bonferroni_head2head.py
+++ b/tests/unit/test_run_bonferroni_head2head.py
@@ -3,8 +3,8 @@ import json
 import pandas as pd
 
 import farkle.run_bonferroni_head2head as rb
-from farkle.strategies import ThresholdStrategy
 from farkle.simulation import simulate_many_games_from_seeds
+from farkle.strategies import ThresholdStrategy
 
 
 def test_simulate_many_games_from_seeds(monkeypatch):

--- a/tests/unit/test_scoring_lookup_validation.py
+++ b/tests/unit/test_scoring_lookup_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from farkle.scoring_lookup import score_roll, evaluate
+from farkle.scoring_lookup import evaluate, score_roll
 
 
 def test_score_roll_rejects_invalid_faces():


### PR DESCRIPTION
## Summary
- fix import sorting in `test_run_bonferroni_head2head.py`
- fix import sorting in `test_scoring_lookup_validation.py`

## Testing
- `pytest tests/unit/test_run_bonferroni_head2head.py::test_run_bonferroni_head2head_writes_csv -q`
- `pytest tests/unit/test_scoring_lookup_validation.py::test_score_roll_rejects_invalid_faces tests/unit/test_run_bonferroni_head2head.py::test_simulate_many_games_from_seeds -q`


------
https://chatgpt.com/codex/tasks/task_e_68804896fdf0832fbc7d0a60c5934d95