### PR TITLE
Add module docstring for run_trueskill

### DIFF
--- a/src/farkle/run_trueskill.py
+++ b/src/farkle/run_trueskill.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+"""Compute TrueSkill ratings for Farkle strategies.
+
+The script scans the ``data/results`` directory for completed tournament
+blocks, updates ratings with the ``trueskill`` package and writes per-block
+as well as pooled rating files.  A ``tiers.json`` file mapping strategies to
+league tiers is also produced.
+"""
+
 import argparse
 import json
 import logging
@@ -54,7 +62,6 @@ def _read_row_shards(row_dir: Path) -> pd.DataFrame:
     if not frames:
         return pd.DataFrame()
     return pd.concat(frames, ignore_index=True)
-
 
 
 def _read_winners_csv(block: Path) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- add a brief module docstring to `run_trueskill.py`

## Testing
- `black --check src/farkle/run_trueskill.py`
- `mypy src/farkle/run_trueskill.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68809ed857f8832f8e4b9ca76f76c6f9