### PR TITLE
Add module docstring to utils

### DIFF
--- a/src/farkle/utils.py
+++ b/src/farkle/utils.py
@@ -1,3 +1,16 @@
+"""Utility helpers for statistical analysis and scheduling.
+
+This module exposes a small collection of functions that support the
+simulation framework:
+
+* ``build_tiers`` groups strategies into overlapping confidence tiers.
+* ``benjamini_hochberg``/``bh_correct`` perform false discovery rate control.
+* ``bonferroni_pairs`` creates deterministic head‑to‑head schedules with RNG
+  seeds.
+
+``MAX_UINT32`` is provided for generating 32‑bit seeds.
+"""
+
 from __future__ import annotations
 
 import itertools


### PR DESCRIPTION
## Summary
- document the utilities module with an overview

## Testing
- `pytest tests/unit/test_utils_functions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a30b95ec832f97325401d0a6e55b