### PR TITLE
Fix warning in plot_partial_dependence

### DIFF
--- a/src/farkle/run_rf.py
+++ b/src/farkle/run_rf.py
@@ -50,6 +50,11 @@ def plot_partial_dependence(model, X, column: str, out_dir: Path) -> Path:
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
+    # ``PartialDependenceDisplay`` currently warns if integer dtypes are passed
+    # for feature columns. Casting avoids the warning and future ``ValueError``
+    # in scikit-learn 1.9.
+    X = X.copy()
+    X[column] = X[column].astype(float)
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",


### PR DESCRIPTION
## Summary
- cast integer columns to float in `plot_partial_dependence`
- run the full test suite

## Testing
- `pytest tests/unit/test_run_rf_helpers.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ab74cd88832f86fc71b8507cb91e