### PR TITLE
Fix test_run_rf_functionality dataset

### DIFF
--- a/tests/unit/test_run_rf_functionality.py
+++ b/tests/unit/test_run_rf_functionality.py
@@ -12,9 +12,12 @@ from farkle import run_rf, run_trueskill
 def _setup_data(tmp_path: Path) -> Path:
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    metrics = pd.DataFrame({"strategy": ["A"], "feat": [1]})
+    metrics = pd.DataFrame({"strategy": ["A", "B"], "feat": [1, 2]})
     metrics.to_parquet(data_dir / "metrics.parquet")
-    ratings = {"A": run_trueskill.RatingStats(0.0, 1.0)}
+    ratings = {
+        "A": run_trueskill.RatingStats(0.0, 1.0),
+        "B": run_trueskill.RatingStats(0.0, 1.0),
+    }
     with open(data_dir / "ratings_pooled.pkl", "wb") as fh:
         pickle.dump(ratings, fh)
     return data_dir


### PR DESCRIPTION
## Summary
- update `_setup_data` in test_run_rf_functionality to provide at least two records

## Testing
- `pytest -q tests/unit/test_run_rf_functionality.py`

------
https://chatgpt.com/codex/tasks/task_e_6880abac8b20832fba0ed5ca3fbf925b