### PR TITLE
Fix run_tournament memory leak

### DIFF
--- a/src/farkle/run_tournament.py
+++ b/src/farkle/run_tournament.py
@@ -409,6 +409,8 @@ def run_tournament(
         futures = {pool.submit(chunk_fn, c): c for c in chunks}
 
         for done, fut in enumerate(as_completed(futures), 1):
+            # drop the original chunk list to free memory while keeping the key
+            futures[fut] = None
             result = fut.result()
             if collect_metrics or collect_rows:
                 wins, sums, sqs = cast(


### PR DESCRIPTION
## Summary
- break reference to completed chunks in `run_tournament`
- install missing dependencies for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882004f082c832fb4465219a17b59b0