### PR TITLE
Prevent memory buildup after writing rows

### DIFF
--- a/src/farkle/run_full_field.py
+++ b/src/farkle/run_full_field.py
@@ -36,6 +36,7 @@ def _concat_row_shards(out_dir: Path, n_players: int) -> None:
     df = pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
     df.to_parquet(out_dir / f"{n_players}p_rows.parquet")
     shutil.rmtree(row_dir, ignore_errors=True)
+    del df  # free memory before returning
 
 
 def _combo_complete(out_dir: Path, n_players: int) -> bool:

--- a/src/farkle/run_tournament.py
+++ b/src/farkle/run_tournament.py
@@ -256,6 +256,7 @@ def _run_chunk_metrics(
             assert row_dir is not None
             out = row_dir / f"rows_{mp.current_process().pid}_{time.time_ns()}.parquet"
             pq.write_table(pa.Table.from_pylist(all_rows), out)
+            all_rows.clear()  # drop rows from memory once persisted
 
     return wins_total, sums_total, sq_total
 


### PR DESCRIPTION
## Summary
- free tournament row data after persisting parquet shards
- drop concatenated DataFrame in `run_full_field` after merging shards

## Testing
- `pip install --exists-action i -q -r requirements.txt` *(fails: not a Python project)*
- `pytest -q` *(fails: missing modules like `yaml` and `numba`)*

------
https://chatgpt.com/codex/tasks/task_e_6882b85c89f0832fb1923b24c4024ad6