### PR TITLE
Add tests for untested strategy logic

### DIFF
--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -111,6 +111,24 @@ def test_auto_hot_dice_forces_roll():
     assert p_cold.score == 2500  # banked after first roll
 
 
+def test_auto_hot_dice_records_hot_roll():
+    seq = [1, 2, 3, 4, 5, 6, 2, 2, 3, 3, 4, 6]
+    rng = fixed_rng_2(seq)
+
+    strat_hot = ThresholdStrategy(score_threshold=0, dice_threshold=6, auto_hot_dice=True)
+    strat_cold = ThresholdStrategy(score_threshold=0, dice_threshold=6, auto_hot_dice=False)
+
+    p_hot = FarklePlayer("H", strat_hot, rng=rng)
+    p_cold = FarklePlayer("C", strat_cold, rng=rng)
+
+    p_hot.take_turn(target_score=10_000)
+    p_cold.take_turn(target_score=10_000)
+
+    assert p_hot.n_hot_dice == 1
+    assert p_hot.n_rolls == 2
+    assert p_cold.n_rolls == 1
+
+
 class SeqGen2(np.random.Generator):
     """Deterministic RNG that cycles through *seq* forever."""
     

--- a/tests/unit/test_strategies.py
+++ b/tests/unit/test_strategies.py
@@ -228,6 +228,21 @@ def test_parse_strategy_valid(input_str, expected):
     assert reparsed.run_up_score == strat.run_up_score
 
 
+def test_parse_strategy_round_trip_str():
+    s = "Strat(500,1)[S-][--FD][OR][-R]"
+    assert str(parse_strategy(s)) == s
+
+
+def test_entry_gate_requires_rolling():
+    strat = ThresholdStrategy(score_threshold=300, dice_threshold=2)
+    assert strat.decide(
+        turn_score=400,
+        dice_left=3,
+        has_scored=False,
+        score_needed=1000,
+    )
+
+
 # ────────────────────────────────────────────────────────────────────────────
 # 2) A collection of malformed strings that should all raise ValueError
 # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add explicit check that hot-dice rolls increment `n_hot_dice`
- verify `parse_strategy` round-trips
- ensure entry gate logic forces another roll

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885e357abf0832fbbaf4e80624ba01b