### PR TITLE
Add dataroot option for analysis scripts

### DIFF
--- a/src/farkle/analysis_pipeline.py
+++ b/src/farkle/analysis_pipeline.py
@@ -45,6 +45,7 @@ log = logging.getLogger(__name__)
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _safe_link(src: Path, dst: Path) -> None:
     """Create *dst* → *src* directory symlink or fall back to copytree.
 
@@ -85,32 +86,40 @@ def _load_results_df(block: Path) -> pd.DataFrame:
 def _strategy_metrics(df: pd.DataFrame) -> pd.DataFrame:
     """Compute wins / avg rounds / avg score per *winner* strategy."""
     if df.empty:
-        return pd.DataFrame(columns=[
-            "strategy",
-            "wins",
-            "avg_rounds",
-            "avg_score",
-        ])
+        return pd.DataFrame(
+            columns=[
+                "strategy",
+                "wins",
+                "avg_rounds",
+                "avg_score",
+            ]
+        )
 
     if "winner_strategy" in df.columns:
         winner_col = "winner_strategy"
     elif "winner" in df.columns:
         winner_col = "winner"
     else:
-        return pd.DataFrame(columns=[
-            "strategy",
-            "wins",
-            "avg_rounds",
-            "avg_score",
-        ])
+        return pd.DataFrame(
+            columns=[
+                "strategy",
+                "wins",
+                "avg_rounds",
+                "avg_score",
+            ]
+        )
 
     grouped = df.groupby(winner_col)
-    out = pd.DataFrame({
-        "strategy": grouped.size().index,
-        "wins": grouped.size().values,
-        "avg_rounds": grouped["n_rounds"].mean() if "n_rounds" in df.columns else float("nan"),
-        "avg_score": grouped["winning_score"].mean() if "winning_score" in df.columns else float("nan"),
-    })
+    out = pd.DataFrame(
+        {
+            "strategy": grouped.size().index,
+            "wins": grouped.size().values,
+            "avg_rounds": grouped["n_rounds"].mean() if "n_rounds" in df.columns else float("nan"),
+            "avg_score": (
+                grouped["winning_score"].mean() if "winning_score" in df.columns else float("nan")
+            ),
+        }
+    )
     return out
 
 
@@ -118,7 +127,10 @@ def _strategy_metrics(df: pd.DataFrame) -> pd.DataFrame:
 # Public entry‑point
 # ---------------------------------------------------------------------------
 
-def run_analysis_pipeline(seed_folder: str | Path) -> Path:  # noqa: C901 – acceptable for orchestrator
+
+def run_analysis_pipeline(
+    seed_folder: str | Path,
+) -> Path:  # noqa: C901 – acceptable for orchestrator
     """Run the full analysis chain for the given *result seed* directory.
 
     Parameters
@@ -169,9 +181,9 @@ def run_analysis_pipeline(seed_folder: str | Path) -> Path:  # noqa: C901 – ac
     cwd = Path.cwd()
     os.chdir(analysis_dir)
     try:
-        run_trueskill.run_trueskill()
-        run_bonferroni_head2head.run_bonferroni_head2head()
-        run_rf.run_rf()
+        run_trueskill.run_trueskill(dataroot=data_dir)
+        run_bonferroni_head2head.run_bonferroni_head2head(dataroot=data_dir)
+        run_rf.run_rf(dataroot=data_dir)
     finally:
         os.chdir(cwd)
 

--- a/src/farkle/run_rf.py
+++ b/src/farkle/run_rf.py
@@ -23,10 +23,11 @@ from sklearn.inspection import PartialDependenceDisplay, permutation_importance
 # ---------------------------------------------------------------------------
 # Constants for file and directory locations used in this module
 # ---------------------------------------------------------------------------
-METRICS_PATH = Path("data/metrics.parquet")
-RATINGS_PATH = Path("data/ratings_pooled.pkl")
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DATA_ROOT = PROJECT_ROOT / "data"
+METRICS_NAME = "metrics.parquet"
+RATINGS_NAME = "ratings_pooled.pkl"
 FIG_DIR = Path("notebooks/figs")
-IMPORTANCE_PATH = Path("data/rf_importance.json")
 
 
 def plot_partial_dependence(model, X, column: str, out_dir: Path) -> Path:
@@ -67,32 +68,40 @@ def plot_partial_dependence(model, X, column: str, out_dir: Path) -> Path:
     return out_file
 
 
-def run_rf(seed: int = 0, output_path: Path = IMPORTANCE_PATH) -> None:
+def run_rf(
+    seed: int = 0,
+    output_path: Path | None = None,
+    dataroot: Path = DEFAULT_DATA_ROOT,
+) -> None:
     """Train the regressor and output feature importance and plots.
 
     Parameters
     ----------
     seed : int, optional
         Random seed for model fitting and permutation importance.
-    output_path : Path, optional
+    output_path : Path | None, optional
         Location for the permutation importance JSON file.
 
     Reads
     -----
-    ``data/metrics.parquet``
+    ``<dataroot>/metrics.parquet``
         Per-strategy feature metrics.
-    ``data/ratings_pooled.pkl``
+    ``<dataroot>/ratings_pooled.pkl``
         Pickled mapping of strategy names to pooled ``(mu, sigma)`` tuples.
 
     Writes
     ------
-    ``data/rf_importance.json``
+    ``<dataroot>/rf_importance.json``
         JSON file mapping metric names to permutation importance scores.
     ``notebooks/figs/pd_<feature>.png``
         Partial dependence plots for each metric.
     """
-    metrics = pd.read_parquet(METRICS_PATH)
-    with open(RATINGS_PATH, "rb") as fh:
+    dataroot = Path(dataroot)
+    metrics_path = dataroot / METRICS_NAME
+    ratings_path = dataroot / RATINGS_NAME
+
+    metrics = pd.read_parquet(metrics_path)
+    with open(ratings_path, "rb") as fh:
         ratings = pickle.load(fh)
     rating_df = pd.DataFrame({"strategy": list(ratings), "mu": [v.mu for v in ratings.values()]})
     data = metrics.merge(rating_df, on="strategy", how="inner")
@@ -115,6 +124,9 @@ def run_rf(seed: int = 0, output_path: Path = IMPORTANCE_PATH) -> None:
         c: float(s)
         for c, s in zip(features.columns, perm_importance["importances_mean"], strict=False)
     }
+    if output_path is None:
+        output_path = dataroot / "rf_importance.json"
+
     output_path.parent.mkdir(exist_ok=True)
     with output_path.open("w") as fh:
         json.dump(imp_dict, fh, indent=2, sort_keys=True)
@@ -146,11 +158,12 @@ def main(argv: List[str] | None = None) -> None:
         "-o",
         "--output",
         type=Path,
-        default=IMPORTANCE_PATH,
+        default=None,
         help="Path to write rf_importance.json",
     )
+    parser.add_argument("--dataroot", type=Path, default=DEFAULT_DATA_ROOT)
     args = parser.parse_args(argv or [])
-    run_rf(seed=args.seed, output_path=args.output)
+    run_rf(seed=args.seed, output_path=args.output, dataroot=args.dataroot)
 
 
 if __name__ == "__main__":

--- a/src/farkle/watch_game.py
+++ b/src/farkle/watch_game.py
@@ -18,7 +18,6 @@ import logging
 import random
 from dataclasses import asdict
 from types import MethodType
-from typing import Sequence
 
 import numpy as np
 
@@ -159,7 +158,7 @@ def _patch_default_score() -> None:
 class TracePlayer(FarklePlayer):
     """Subclass of :class:`FarklePlayer` that logs every dice roll."""
 
-    def _roll(self, n: int) -> Sequence[int]:
+    def _roll(self, n: int) -> list[int]:
         """Return ``n`` dice faces and log the result."""
         faces = super()._roll(n)
         log.info(f"{self.name} rolls {faces}")

--- a/tests/unit/test_analysis_pipeline.py
+++ b/tests/unit/test_analysis_pipeline.py
@@ -46,8 +46,8 @@ def test_analysis_pipeline(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        run_trueskill.main(["--output-seed", "0"])
-        run_rf.main([])
+        run_trueskill.main(["--output-seed", "0", "--dataroot", str(data_root)])
+        run_rf.main(["--dataroot", str(data_root)])
 
         assert (data_root / "rf_importance.json").exists()
         figs = tmp_path / "notebooks" / "figs"
@@ -90,6 +90,6 @@ def test_run_rf_missing_files(tmp_path, missing):
     os.chdir(tmp_path)
     try:
         with pytest.raises(FileNotFoundError):
-            run_rf.run_rf()
+            run_rf.run_rf(dataroot=data_dir)
     finally:
         os.chdir(cwd)

--- a/tests/unit/test_run_rf_functionality.py
+++ b/tests/unit/test_run_rf_functionality.py
@@ -29,7 +29,7 @@ def test_run_rf_custom_output_path(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        run_rf.run_rf(output_path=out_file)
+        run_rf.run_rf(output_path=out_file, dataroot=data_dir)
     finally:
         os.chdir(cwd)
     assert out_file.exists()
@@ -48,6 +48,6 @@ def test_run_rf_importance_length_check(tmp_path, monkeypatch):
     os.chdir(tmp_path)
     try:
         with pytest.raises(ValueError, match="Mismatch between number of features"):
-            run_rf.run_rf(output_path=data_dir / "out.json")
+            run_rf.run_rf(output_path=data_dir / "out.json", dataroot=data_dir)
     finally:
         os.chdir(cwd)

--- a/tests/unit/test_run_trueskill_helpers.py
+++ b/tests/unit/test_run_trueskill_helpers.py
@@ -85,9 +85,9 @@ def test_load_ranked_games_csv(tmp_path):
 
 
 def test_load_ranked_games_multi_row_dirs(tmp_path):
-    block   = tmp_path / "m_players"
-    row1    = block / "1_rows"
-    row2    = block / "2_rows"
+    block = tmp_path / "m_players"
+    row1 = block / "1_rows"
+    row2 = block / "2_rows"
     row1.mkdir(parents=True)
     row2.mkdir()
     pd.DataFrame({"winner_strategy": ["A"]}).to_parquet(row1 / "a.parquet")
@@ -159,7 +159,7 @@ def test_run_trueskill_incomplete_block(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        rt.run_trueskill()
+        rt.run_trueskill(dataroot=data_root)
     finally:
         os.chdir(cwd)
 
@@ -190,7 +190,7 @@ def test_run_trueskill_with_suffix(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        rt.run_trueskill(output_seed=1)
+        rt.run_trueskill(output_seed=1, dataroot=data_root)
     finally:
         os.chdir(cwd)
 

--- a/tests/unit/test_run_trueskill_pooling.py
+++ b/tests/unit/test_run_trueskill_pooling.py
@@ -17,26 +17,30 @@ def test_pooled_ratings_are_mean(tmp_path):
     # --- block with A beating B -------------------------------------------------
     block2 = res_root / "2_players" / "1_rows"
     block2.mkdir(parents=True)
-    df2 = pd.DataFrame({
-        "P1_strategy": ["A"] * 3,
-        "P1_rank": [1] * 3,
-        "P2_strategy": ["B"] * 3,
-        "P2_rank": [2] * 3,
-    })
+    df2 = pd.DataFrame(
+        {
+            "P1_strategy": ["A"] * 3,
+            "P1_rank": [1] * 3,
+            "P2_strategy": ["B"] * 3,
+            "P2_rank": [2] * 3,
+        }
+    )
     df2.to_parquet(block2 / "rows.parquet")
     np.save(block2.parent / "keepers_2.npy", np.array(["A", "B"]))
 
     # --- block with B beating A (extra player ignored) -------------------------
     block3 = res_root / "3_players" / "1_rows"
     block3.mkdir(parents=True)
-    df3 = pd.DataFrame({
-        "P1_strategy": ["B"] * 3,
-        "P1_rank": [1] * 3,
-        "P2_strategy": ["A"] * 3,
-        "P2_rank": [2] * 3,
-        "P3_strategy": ["C"] * 3,
-        "P3_rank": [3] * 3,
-    })
+    df3 = pd.DataFrame(
+        {
+            "P1_strategy": ["B"] * 3,
+            "P1_rank": [1] * 3,
+            "P2_strategy": ["A"] * 3,
+            "P2_rank": [2] * 3,
+            "P3_strategy": ["C"] * 3,
+            "P3_rank": [3] * 3,
+        }
+    )
     df3.to_parquet(block3 / "rows.parquet")
     np.save(block3.parent / "keepers_3.npy", np.array(["A", "B"]))
 
@@ -49,7 +53,7 @@ def test_pooled_ratings_are_mean(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        run_trueskill.main([])
+        run_trueskill.main(["--dataroot", str(data_root)])
     finally:
         os.chdir(cwd)
 
@@ -77,4 +81,3 @@ def test_pooled_ratings_are_mean(tmp_path):
     assert r2 == expected2
     assert r3 == expected3
     assert pooled == expected_pooled
-


### PR DESCRIPTION
## Summary
- support configurable `--dataroot` in Bonferroni analysis, TrueSkill ratings and random forest training
- update analysis pipeline to pass data directory
- adjust unit tests for new argument
- minor fix to `watch_game` for mypy

## Testing
- `ruff check src/farkle`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688887a854f0832f9834c84c558720cb