### PR TITLE
Add progress logging to run_tournament

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Run a tournament from a config file:
 python -m farkle run cfg.yml
 ```
 
+You can get progress logs with `--log-level INFO`.
+
 Use the API directly:
 
 ```python

--- a/src/farkle/logging_utils.py
+++ b/src/farkle/logging_utils.py
@@ -1,0 +1,12 @@
+
+def setup_logging(level: str = "WARNING"):
+    import logging
+    import sys
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.WARNING),
+        format="%(asctime)s [%(process)d] %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        stream=sys.stderr,
+        force=True,
+    )
+


### PR DESCRIPTION
## Summary
- add `logging_utils.setup_logging` helper
- wire lightweight shuffle logging in `run_tournament`
- expose `--log-level` CLI option and document it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889931f00dc832f80aff074b160cd95