### PR TITLE
Add configurable data root for analysis scripts

### DIFF
--- a/src/farkle/analysis_pipeline.py
+++ b/src/farkle/analysis_pipeline.py
@@ -162,9 +162,9 @@
 #     cwd = Path.cwd()
 #     os.chdir(analysis_dir)
 #     try:
-#         run_trueskill.run_trueskill(dataroot=data_dir)
-#         run_bonferroni_head2head.run_bonferroni_head2head(dataroot=data_dir)
-#         run_rf.run_rf(dataroot=data_dir)
+#         run_trueskill.run_trueskill(root=data_dir)
+#         run_bonferroni_head2head.run_bonferroni_head2head(root=data_dir)
+#         run_rf.run_rf(root=data_dir)
 #     finally:
 #         os.chdir(cwd)
 

--- a/src/farkle/run_bonferroni_head2head.py
+++ b/src/farkle/run_bonferroni_head2head.py
@@ -16,11 +16,10 @@ from farkle.stats import games_for_power
 from farkle.strategies import parse_strategy
 from farkle.utils import bonferroni_pairs
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATA_ROOT = PROJECT_ROOT / "data"
+DEFAULT_ROOT = Path("data")
 
 
-def run_bonferroni_head2head(seed: int = 0, dataroot: Path = DEFAULT_DATA_ROOT) -> None:
+def run_bonferroni_head2head(seed: int = 0, root: Path = DEFAULT_ROOT) -> None:
     """Run pairwise games between top-tier strategies using Bonferroni tests.
 
     Parameters
@@ -33,9 +32,9 @@ def run_bonferroni_head2head(seed: int = 0, dataroot: Path = DEFAULT_DATA_ROOT) 
     matchup and writes ``data/bonferroni_pairwise.csv`` containing win counts and
     p-values computed via :func:`scipy.stats.binomtest`.
     """
-    dataroot = Path(dataroot)
-    tiers_path = dataroot / "tiers.json"
-    pairwise_csv = dataroot / "bonferroni_pairwise.csv"
+    root = Path(root)
+    tiers_path = root / "tiers.json"
+    pairwise_csv = root / "bonferroni_pairwise.csv"
 
     try:
         with tiers_path.open() as fh:
@@ -74,9 +73,9 @@ def main(argv: List[str] | None = None) -> None:
     """
     parser = argparse.ArgumentParser(description="Head-to-head Bonferroni analysis")
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--dataroot", type=Path, default=DEFAULT_DATA_ROOT)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
     args = parser.parse_args(argv)
-    run_bonferroni_head2head(seed=args.seed, dataroot=args.dataroot)
+    run_bonferroni_head2head(seed=args.seed, root=args.root)
 
 
 if __name__ == "__main__":

--- a/src/farkle/run_rf.py
+++ b/src/farkle/run_rf.py
@@ -23,8 +23,7 @@ from sklearn.inspection import PartialDependenceDisplay, permutation_importance
 # ---------------------------------------------------------------------------
 # Constants for file and directory locations used in this module
 # ---------------------------------------------------------------------------
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATA_ROOT = PROJECT_ROOT / "data"
+DEFAULT_ROOT = Path("data")
 METRICS_NAME = "metrics.parquet"
 RATINGS_NAME = "ratings_pooled.pkl"
 FIG_DIR = Path("notebooks/figs")
@@ -71,7 +70,7 @@ def plot_partial_dependence(model, X, column: str, out_dir: Path) -> Path:
 def run_rf(
     seed: int = 0,
     output_path: Path | None = None,
-    dataroot: Path = DEFAULT_DATA_ROOT,
+    root: Path = DEFAULT_ROOT,
 ) -> None:
     """Train the regressor and output feature importance and plots.
 
@@ -84,21 +83,21 @@ def run_rf(
 
     Reads
     -----
-    ``<dataroot>/metrics.parquet``
+    ``<root>/metrics.parquet``
         Per-strategy feature metrics.
-    ``<dataroot>/ratings_pooled.pkl``
+    ``<root>/ratings_pooled.pkl``
         Pickled mapping of strategy names to pooled ``(mu, sigma)`` tuples.
 
     Writes
     ------
-    ``<dataroot>/rf_importance.json``
+    ``<root>/rf_importance.json``
         JSON file mapping metric names to permutation importance scores.
     ``notebooks/figs/pd_<feature>.png``
         Partial dependence plots for each metric.
     """
-    dataroot = Path(dataroot)
-    metrics_path = dataroot / METRICS_NAME
-    ratings_path = dataroot / RATINGS_NAME
+    root = Path(root)
+    metrics_path = root / METRICS_NAME
+    ratings_path = root / RATINGS_NAME
 
     metrics = pd.read_parquet(metrics_path)
     with open(ratings_path, "rb") as fh:
@@ -125,7 +124,7 @@ def run_rf(
         for c, s in zip(features.columns, perm_importance["importances_mean"], strict=False)
     }
     if output_path is None:
-        output_path = dataroot / "rf_importance.json"
+        output_path = root / "rf_importance.json"
 
     output_path.parent.mkdir(exist_ok=True)
     with output_path.open("w") as fh:
@@ -161,9 +160,9 @@ def main(argv: List[str] | None = None) -> None:
         default=None,
         help="Path to write rf_importance.json",
     )
-    parser.add_argument("--dataroot", type=Path, default=DEFAULT_DATA_ROOT)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
     args = parser.parse_args(argv or [])
-    run_rf(seed=args.seed, output_path=args.output, dataroot=args.dataroot)
+    run_rf(seed=args.seed, output_path=args.output, root=args.root)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_analysis_pipeline.py
+++ b/tests/unit/test_analysis_pipeline.py
@@ -46,8 +46,8 @@
 #     cwd = os.getcwd()
 #     os.chdir(tmp_path)
 #     try:
-#         run_trueskill.main(["--output-seed", "0", "--dataroot", str(data_root)])
-#         run_rf.main(["--dataroot", str(data_root)])
+#         run_trueskill.main(["--output-seed", "0", "--root", str(data_root)])
+#         run_rf.main(["--root", str(data_root)])
 
 #         assert (data_root / "rf_importance.json").exists()
 #         figs = tmp_path / "notebooks" / "figs"
@@ -90,6 +90,6 @@
 #     os.chdir(tmp_path)
 #     try:
 #         with pytest.raises(FileNotFoundError):
-#             run_rf.run_rf(dataroot=data_dir)
+#             run_rf.run_rf(root=data_dir)
 #     finally:
 #         os.chdir(cwd)

--- a/tests/unit/test_run_bonferroni_head2head.py
+++ b/tests/unit/test_run_bonferroni_head2head.py
@@ -55,7 +55,7 @@ def test_run_bonferroni_head2head_writes_csv(tmp_path, monkeypatch):
 
     monkeypatch.setattr(rb, "simulate_many_games", fake_many_games)
 
-    rb.run_bonferroni_head2head(seed=0, dataroot=data_dir)
+    rb.run_bonferroni_head2head(seed=0, root=data_dir)
     out_csv = data_dir / "bonferroni_pairwise.csv"
     df = pd.read_csv(out_csv)
     assert set(df.columns) == {"a", "b", "wins_a", "wins_b", "pvalue"}
@@ -79,7 +79,7 @@ def test_run_bonferroni_head2head_single_strategy(tmp_path, monkeypatch):
         rb, "simulate_many_games", lambda **k: pd.DataFrame({"winner_strategy": []})
     )
 
-    rb.run_bonferroni_head2head(seed=0, dataroot=data_dir)
+    rb.run_bonferroni_head2head(seed=0, root=data_dir)
     out_csv = data_dir / "bonferroni_pairwise.csv"
     assert out_csv.exists()
     assert out_csv.read_text() == "\n"
@@ -89,7 +89,7 @@ def test_run_bonferroni_head2head_missing_file(tmp_path, monkeypatch):
     """An informative error is raised when tiers.json is absent."""
     monkeypatch.chdir(tmp_path)
     with pytest.raises(RuntimeError, match="Tier file not found"):
-        rb.run_bonferroni_head2head(seed=1, dataroot=tmp_path / "data")
+        rb.run_bonferroni_head2head(seed=1, root=tmp_path / "data")
 
 
 def test_run_bonferroni_head2head_empty_file(tmp_path, monkeypatch):
@@ -98,16 +98,16 @@ def test_run_bonferroni_head2head_empty_file(tmp_path, monkeypatch):
     (data_dir / "tiers.json").write_text("{}")
     monkeypatch.chdir(tmp_path)
     with pytest.raises(RuntimeError, match="No tiers found"):
-        rb.run_bonferroni_head2head(dataroot=data_dir)
+        rb.run_bonferroni_head2head(root=data_dir)
 
 
 def test_main_delegates_to_runner(monkeypatch):
     captured = {}
 
-    def fake_run(seed: int = 0, dataroot=None) -> None:  # noqa: ANN001
-        _ = dataroot
+    def fake_run(seed: int = 0, root=None) -> None:  # noqa: ANN001
+        _ = root
         captured["seed"] = seed
 
     monkeypatch.setattr(rb, "run_bonferroni_head2head", fake_run)
-    rb.main(["--seed", "42", "--dataroot", "d"])
+    rb.main(["--seed", "42", "--root", "d"])
     assert captured["seed"] == 42

--- a/tests/unit/test_run_rf_functionality.py
+++ b/tests/unit/test_run_rf_functionality.py
@@ -29,7 +29,7 @@ def test_run_rf_custom_output_path(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        run_rf.run_rf(output_path=out_file, dataroot=data_dir)
+        run_rf.run_rf(output_path=out_file, root=data_dir)
     finally:
         os.chdir(cwd)
     assert out_file.exists()
@@ -48,6 +48,6 @@ def test_run_rf_importance_length_check(tmp_path, monkeypatch):
     os.chdir(tmp_path)
     try:
         with pytest.raises(ValueError, match="Mismatch between number of features"):
-            run_rf.run_rf(output_path=data_dir / "out.json", dataroot=data_dir)
+            run_rf.run_rf(output_path=data_dir / "out.json", root=data_dir)
     finally:
         os.chdir(cwd)

--- a/tests/unit/test_run_tournament.py
+++ b/tests/unit/test_run_tournament.py
@@ -398,6 +398,7 @@ def test_run_tournament_cli(monkeypatch):
             3,
         )
         row_dir = Path("rows")
+        log_level = "INFO"
 
     monkeypatch.setattr(rt.argparse, "ArgumentParser", lambda *a, **k: type("P", (), {"add_argument": lambda *a, **k: None, "parse_args": lambda _: DummyArgs})())  # noqa: ARG005
 

--- a/tests/unit/test_run_trueskill_helpers.py
+++ b/tests/unit/test_run_trueskill_helpers.py
@@ -159,7 +159,7 @@ def test_run_trueskill_incomplete_block(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        rt.run_trueskill(dataroot=data_root)
+        rt.run_trueskill(root=data_root)
     finally:
         os.chdir(cwd)
 
@@ -190,7 +190,7 @@ def test_run_trueskill_with_suffix(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        rt.run_trueskill(output_seed=1, dataroot=data_root)
+        rt.run_trueskill(output_seed=1, root=data_root)
     finally:
         os.chdir(cwd)
 

--- a/tests/unit/test_run_trueskill_pooling.py
+++ b/tests/unit/test_run_trueskill_pooling.py
@@ -53,7 +53,7 @@ def test_pooled_ratings_are_mean(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        run_trueskill.main(["--dataroot", str(data_root)])
+        run_trueskill.main(["--root", str(data_root)])
     finally:
         os.chdir(cwd)
 


### PR DESCRIPTION
## Summary
- allow setting a root directory for run_trueskill to avoid hard-coded `data` paths
- make head-to-head and random forest utilities respect a `--root` CLI option
- update tests for new CLI argument

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f339078a4832faca7ef819ee40ae7