### PR TITLE
Refactor analysis path handling and CLI parsing

### DIFF
--- a/src/farkle/analysis_config.py
+++ b/src/farkle/analysis_config.py
@@ -13,6 +13,7 @@ def main():
 """
 from __future__ import annotations
 
+import argparse
 import json
 import os
 from dataclasses import dataclass, field
@@ -56,6 +57,7 @@ class PipelineCfg:
 
     # 5. logging & provenance
     log_level: str = "INFO"
+    log_file: Path | None = None           # e.g. Path("analysis/pipeline.log")
     manifest_name: str = "manifest.json"
     git_sha: str | None = None   # filled on __post_init__
 
@@ -76,19 +78,55 @@ class PipelineCfg:
 
     # Convenience helpers
     # -------------------
-    def data_dir(self) -> Path:
-        return self.root  # alias if you like cfg.data_dir()
-
+    @property
     def analysis_dir(self) -> Path:
-        return self.root.parent / self.analysis_subdir
+        """Directory where analysis artifacts are written."""
+        return self.root / self.analysis_subdir
+
+    @property
+    def data_dir(self) -> Path:
+        """Subdirectory beneath :pyattr:`analysis_dir` holding intermediate data."""
+        return self.analysis_dir / "data"
+
+    @property
+    def curated_parquet(self) -> Path:
+        """Location of the curated game rows parquet."""
+        return self.data_dir / self.curated_rows_name
 
     def to_json(self) -> str:
-        return json.dumps(self, default=lambda o: str(o) if isinstance(o, Path) else o, indent=2)
-    
-    # ── Logging ────────────────────────────────────────────────────────────
-    log_level: str = "INFO"                # default matches your new choice
-    log_file: Path | None = None           # e.g. Path("analysis/pipeline.log")
+        return json.dumps(
+            self,
+            default=lambda o: str(o) if isinstance(o, Path) else o,
+            indent=2,
+        )
 
     # Convenience: return kwargs ready for setup_logging()
     def logging_params(self) -> dict[str, object]:
         return {"level": self.log_level, "log_file": self.log_file}
+
+    # CLI -----------------------------------------------------------------
+    @classmethod
+    def parse_cli(cls, argv: list[str] | None = None) -> "PipelineCfg":
+        """Parse command line options into a :class:`PipelineCfg` instance."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--root", type=Path, default=Path("data"))
+        parser.add_argument(
+            "--run-trueskill",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            dest="run_trueskill",
+        )
+        parser.add_argument(
+            "--run-head2head",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            dest="run_head2head",
+        )
+        parser.add_argument(
+            "--run-rf",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            dest="run_rf",
+        )
+        args = parser.parse_args(argv)
+        return cls(**vars(args))

--- a/src/farkle/curate.py
+++ b/src/farkle/curate.py
@@ -57,13 +57,11 @@ def run(cfg: PipelineCfg) -> None:
     •  Writes <analysis_dir>/manifest.json
     •  Logs progress with the same logger used by ingest.py
     """
-    analysis_dir = cfg.root / cfg.analysis_subdir
-    data_dir = analysis_dir / "data"
-    data_dir.mkdir(parents=True, exist_ok=True)
+    cfg.data_dir.mkdir(parents=True, exist_ok=True)
 
-    src_tmp  = data_dir / (cfg.curated_rows_name + ".in-progress")
-    dst_file = data_dir / cfg.curated_rows_name
-    manifest = analysis_dir / cfg.manifest_name
+    src_tmp = cfg.curated_parquet.with_suffix(".in-progress")
+    dst_file = cfg.curated_parquet
+    manifest = cfg.analysis_dir / cfg.manifest_name
 
     if _already_curated(dst_file, manifest):
         log.info("Curate: %s already up-to-date – skipped", dst_file.name)
@@ -71,7 +69,7 @@ def run(cfg: PipelineCfg) -> None:
 
     #  Stream-copy the row-groups exactly as ingest produced them
     src_rows = 0
-    source_pq = data_dir / cfg.curated_rows_name  # ingest’s output
+    source_pq = cfg.curated_parquet  # ingest’s output
     if not source_pq.exists():
         raise FileNotFoundError(source_pq)
 

--- a/src/farkle/ingest.py
+++ b/src/farkle/ingest.py
@@ -78,10 +78,8 @@ def _fix_winner(df: pd.DataFrame) -> pd.DataFrame:
 def run(cfg: PipelineCfg) -> None:
     log.info("Ingest started: root=%s", cfg.root)
 
-    analysis_dir = cfg.root / cfg.analysis_subdir
-    data_dir     = analysis_dir / "data"
-    data_dir.mkdir(parents=True, exist_ok=True)
-    out_path     = data_dir / cfg.curated_rows_name
+    cfg.data_dir.mkdir(parents=True, exist_ok=True)
+    out_path = cfg.curated_parquet
     if out_path.exists():
         out_path.unlink()  # remove old file; idempotent
 

--- a/src/farkle/metrics.py
+++ b/src/farkle/metrics.py
@@ -55,9 +55,9 @@ def run(cfg: PipelineCfg) -> None:
     <analysis_dir>/metrics.parquet         (per-strategy & overall KPIs)
     <analysis_dir>/seat_advantage.csv      (P1..P6 win-rates with CI)
     """
-    analysis_dir = cfg.root / cfg.analysis_subdir
-    data_file = analysis_dir / "data" / cfg.curated_rows_name
-    out_metrics = analysis_dir / "metrics.parquet"
+    analysis_dir = cfg.analysis_dir
+    data_file = cfg.curated_parquet
+    out_metrics = analysis_dir / cfg.metrics_name
     out_seats = analysis_dir / "seat_advantage.csv"
 
     if all(p.exists() and p.stat().st_mtime >= data_file.stat().st_mtime


### PR DESCRIPTION
## Summary
- add `analysis_dir`, `data_dir`, and `curated_parquet` properties to `PipelineCfg`
- provide `parse_cli` classmethod and remove duplicate `log_level`
- update ingest/metrics/curate modules to leverage new config properties

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f367a5ecc832f860fe50180a2ba0d