### PR TITLE
Refactor metrics paths to rely on PipelineCfg

### DIFF
--- a/src/farkle/analysis_config.py
+++ b/src/farkle/analysis_config.py
@@ -76,11 +76,17 @@ class PipelineCfg:
 
     # Convenience helpers
     # -------------------
+    @property
     def data_dir(self) -> Path:
         return self.root  # alias if you like cfg.data_dir()
 
+    @property
     def analysis_dir(self) -> Path:
-        return self.root.parent / self.analysis_subdir
+        return self.root / self.analysis_subdir
+
+    @property
+    def curated_parquet(self) -> Path:
+        return self.analysis_dir / "data" / self.curated_rows_name
 
     def to_json(self) -> str:
         return json.dumps(self, default=lambda o: str(o) if isinstance(o, Path) else o, indent=2)

--- a/src/farkle/metrics.py
+++ b/src/farkle/metrics.py
@@ -55,9 +55,9 @@ def run(cfg: PipelineCfg) -> None:
     <analysis_dir>/metrics.parquet         (per-strategy & overall KPIs)
     <analysis_dir>/seat_advantage.csv      (P1..P6 win-rates with CI)
     """
-    analysis_dir = cfg.root / cfg.analysis_subdir
-    data_file = analysis_dir / "data" / cfg.curated_rows_name
-    out_metrics = analysis_dir / "metrics.parquet"
+    analysis_dir = cfg.analysis_dir
+    data_file = cfg.curated_parquet
+    out_metrics = analysis_dir / cfg.metrics_name
     out_seats = analysis_dir / "seat_advantage.csv"
 
     if all(p.exists() and p.stat().st_mtime >= data_file.stat().st_mtime


### PR DESCRIPTION
## Summary
- centralize metrics paths via `PipelineCfg`
- expose `analysis_dir` and `curated_parquet` as config properties

## Testing
- `pytest -q` *(fails: No module named 'yaml'; No module named 'numba')*


------
https://chatgpt.com/codex/tasks/task_e_688f367c0884832fab9884ccf09076fe