### PR TITLE
Add analysis pipeline CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ farkle = "farkle.farkle_cli:main"
 time-farkle = "farkle.time_farkle:main"
 run-full-field = "farkle.run_full_field:main"
 watch-game = "farkle.watch_game:watch_game"
+farkle-analyse = "farkle.pipeline:main"
 
 # ── 3. Tell Hatchling where the code lives ───────────
 [tool.hatch.build.targets.wheel]

--- a/src/farkle/pipeline.py
+++ b/src/farkle/pipeline.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+from typing import Callable, Sequence
+
+from tqdm import tqdm
+
+from farkle import analytics, curate, ingest, metrics
+from farkle.analysis_config import PipelineCfg
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Console entry point for the analysis pipeline."""
+    cfg, cli_ns, remaining = PipelineCfg.parse_cli(argv)
+
+    parser = argparse.ArgumentParser(prog="farkle-analyse")
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("ingest", "curate", "metrics", "analytics", "all"):
+        sub.add_parser(name)
+
+    args = parser.parse_args(remaining)
+    verbose = getattr(cli_ns, "verbose", False)
+
+    if args.command == "ingest":
+        ingest.run(cfg)
+    elif args.command == "curate":
+        curate.run(cfg)
+    elif args.command == "metrics":
+        metrics.run(cfg)
+    elif args.command == "analytics":
+        analytics.run_all(cfg)
+    elif args.command == "all":
+        steps: list[tuple[str, Callable[[PipelineCfg], None]]] = [
+            ("ingest", ingest.run),
+            ("curate", curate.run),
+            ("metrics", metrics.run),
+            ("analytics", analytics.run_all),
+        ]
+        for _name, fn in tqdm(steps, desc="pipeline", disable=not verbose):
+            fn(cfg)
+    else:  # pragma: no cover - argparse enforces valid choices
+        parser.error(f"Unknown command {args.command}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `pipeline` CLI for running analysis steps via subcommands
- parse shared CLI options with `PipelineCfg.parse_cli`
- expose entry point `farkle-analyse`

## Testing
- `ruff check src/farkle/pipeline.py src/farkle/analysis_config.py pyproject.toml`
- `python -m black src/farkle/pipeline.py src/farkle/analysis_config.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_688f367e9890832f9457760c4cbb0360