### PR TITLE
Lazily compute git SHA

### DIFF
--- a/tests/unit/test_analysis_config_git_sha.py
+++ b/tests/unit/test_analysis_config_git_sha.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from farkle.analysis_config import PipelineCfg
+
+
+def test_git_sha_lazily_computed(monkeypatch):
+    calls = 0
+
+    def fake_load(self):
+        nonlocal calls
+        calls += 1
+        return "abc123"
+
+    monkeypatch.setattr(PipelineCfg, "_load_git_sha", fake_load)
+    cfg = PipelineCfg()
+
+    assert calls == 0
+
+    assert cfg.git_sha == "abc123"
+    assert calls == 1
+
+    # Subsequent access uses cached value
+    assert cfg.git_sha == "abc123"
+    assert calls == 1


### PR DESCRIPTION
## Summary
- avoid running `git rev-parse` during `PipelineCfg` import by retrieving the commit hash lazily
- add regression test ensuring the git SHA is computed only when accessed

## Testing
- `ruff check src/farkle/analysis_config.py tests/unit/test_analysis_config_git_sha.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689013c07f88832fb952c3e01c23ed85