### PR TITLE
Speed up winner extraction in ingest and enforce Parquet schema

### DIFF
--- a/src/farkle/ingest.py
+++ b/src/farkle/ingest.py
@@ -5,6 +5,7 @@ import logging
 import re
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -45,30 +46,28 @@ def _fix_winner(df: pd.DataFrame) -> pd.DataFrame:
         return df
 
     df = df.copy(deep=False)                     # cheap shallow copy
-    seat_cols = [c for c in df.columns if _SEAT_RE.match(c)]
+    seat_cols = sorted(
+        [c for c in df.columns if _SEAT_RE.match(c)],
+        key=lambda c: int(_SEAT_RE.match(c).group(1)),  # natural seat order  # type: ignore
+    )
 
     # --- Step 1: find seat label (P#) that won --------------------------
     df["winner_seat"] = df["winner"]            # winner column still holds P#
 
     # --- Step 2: promote strategy string -------------------------------
-    df["winner_strategy"] = df.apply(
-        lambda r: r[f"{r.winner_seat}_strategy"],
-        axis=1,
-    )
+    seat_idx = df["winner_seat"].str.extract(r"P(\d+)").astype("int64")[0] - 1
+    df["winner_strategy"] = df[seat_cols].to_numpy()[
+        np.arange(len(df)), seat_idx.to_numpy()
+    ]
 
     # --- Step 3: capture finishing order -------------------------------
-    # For each row, build (seat, rank) pairs, then order by rank
-    seat_cols_sorted = sorted(
-        seat_cols,
-        key=lambda c: int(_SEAT_RE.match(c).group(1)),  # natural seat order  # type: ignore
-    )
-
     def _row_to_seat_ranks(row):
-        pairs = [(seat[:-9], row[seat.replace("_strategy", "_rank")])
-                 for seat in seat_cols_sorted]
+        pairs = [
+            (seat[:-9], row[seat.replace("_strategy", "_rank")]) for seat in seat_cols
+        ]
         return tuple(seat for seat, rk in sorted(pairs, key=lambda p: p[1]))
 
-    rank_cols = [c.replace("_strategy", "_rank") for c in seat_cols_sorted]
+    rank_cols = [c.replace("_strategy", "_rank") for c in seat_cols]
     if all(col in df.columns for col in rank_cols):
         df["seat_ranks"] = df.apply(_row_to_seat_ranks, axis=1)
 
@@ -87,34 +86,44 @@ def run(cfg: PipelineCfg) -> None:
     writer = None
     total_rows = 0
 
-    for block in sorted(cfg.root.glob(cfg.results_glob)):
-        log.info("Reading block %s", block.name)
-        expected_cols = set(cfg.ingest_cols)
-        for shard_df, shard_path in _iter_shards(block, cfg.ingest_cols):
-            if shard_df.empty:
-                log.debug("Shard %s is empty — skipped", shard_path.name)
-                continue
-            
-            if set(shard_df.columns) != expected_cols:
-                log.error("Schema mismatch in %s", shard_path)
-                raise RuntimeError("Shard DataFrame columns do not match expected columns")
-            
-            log.debug("Shard %s → %d rows", shard_path.name, len(shard_df))
-            
-            shard_df = _fix_winner(shard_df)
-            total_rows += len(shard_df)
+    try:
+        for block in sorted(cfg.root.glob(cfg.results_glob)):
+            log.info("Reading block %s", block.name)
+            expected_cols = set(cfg.ingest_cols)
+            for shard_df, shard_path in _iter_shards(block, cfg.ingest_cols):
+                if shard_df.empty:
+                    log.debug("Shard %s is empty — skipped", shard_path.name)
+                    continue
 
-            # Lazily open writer on first chunk
-            table = pa.Table.from_pandas(shard_df, preserve_index=False)
-            if writer is None:
-                writer = pq.ParquetWriter(
-                    out_path,
-                    table.schema,
-                    compression=cfg.parquet_codec,
-                )
-            
-            writer.write_table(table, row_group_size=cfg.row_group_size)
+                if set(shard_df.columns) != expected_cols:
+                    log.error("Schema mismatch in %s", shard_path)
+                    raise RuntimeError("Shard DataFrame columns do not match expected columns")
 
-    if writer:
-        writer.close()
+                shard_df = shard_df.reindex(columns=cfg.ingest_cols)
+                log.debug("Shard %s → %d rows", shard_path.name, len(shard_df))
+
+                shard_df = _fix_winner(shard_df)
+                canonical_cols = list(cfg.ingest_cols) + [
+                    "winner_seat",
+                    "winner_strategy",
+                ]
+                if "seat_ranks" in shard_df.columns:
+                    canonical_cols.append("seat_ranks")
+                shard_df = shard_df.reindex(columns=canonical_cols)
+
+                total_rows += len(shard_df)
+
+                # Lazily open writer on first chunk
+                table = pa.Table.from_pandas(shard_df, preserve_index=False)
+                if writer is None:
+                    writer = pq.ParquetWriter(
+                        out_path,
+                        table.schema,
+                        compression=cfg.parquet_codec,
+                    )
+
+                writer.write_table(table, row_group_size=cfg.row_group_size)
+    finally:
+        if writer:
+            writer.close()
     log.info("Ingest finished — %d rows written to %s", total_rows, out_path)


### PR DESCRIPTION
## Summary
- Vectorize winner strategy extraction to avoid per-row `apply`
- Reindex shards and append canonical columns before Parquet write
- Ensure ParquetWriter closes via `try/finally`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689013f97364832fa700844502b1d54b