### PR TITLE
Weight pooled TrueSkill ratings by games

### DIFF
--- a/tests/unit/test_run_trueskill_pooling.py
+++ b/tests/unit/test_run_trueskill_pooling.py
@@ -10,7 +10,7 @@ import yaml
 from farkle import run_trueskill
 
 
-def test_pooled_ratings_are_mean(tmp_path):
+def test_pooled_ratings_are_weighted_mean(tmp_path):
     data_root = tmp_path / "data"
     res_root = data_root / "results"
 
@@ -33,12 +33,12 @@ def test_pooled_ratings_are_mean(tmp_path):
     block3.mkdir(parents=True)
     df3 = pd.DataFrame(
         {
-            "P1_strategy": ["B"] * 3,
-            "P1_rank": [1] * 3,
-            "P2_strategy": ["A"] * 3,
-            "P2_rank": [2] * 3,
-            "P3_strategy": ["C"] * 3,
-            "P3_rank": [3] * 3,
+            "P1_strategy": ["B"] * 6,
+            "P1_rank": [1] * 6,
+            "P2_strategy": ["A"] * 6,
+            "P2_rank": [2] * 6,
+            "P3_strategy": ["C"] * 6,
+            "P3_rank": [3] * 6,
         }
     )
     df3.to_parquet(block3 / "rows.parquet")
@@ -66,14 +66,15 @@ def test_pooled_ratings_are_mean(tmp_path):
 
     env = run_trueskill.trueskill.TrueSkill()
     g2 = [["A", "B"]] * 3
-    g3 = [["B", "A", "C"]] * 3
+    g3 = [["B", "A", "C"]] * 6
     expected2 = run_trueskill._update_ratings(g2, ["A", "B"], env)
     expected3 = run_trueskill._update_ratings(g3, ["A", "B"], env)
 
+    w2, w3 = len(g2), len(g3)
     expected_pooled = {
         k: run_trueskill.RatingStats(
-            (expected2[k].mu + expected3[k].mu) / 2,
-            (expected2[k].sigma + expected3[k].sigma) / 2,
+            (expected2[k].mu * w2 + expected3[k].mu * w3) / (w2 + w3),
+            (expected2[k].sigma * w2 + expected3[k].sigma * w3) / (w2 + w3),
         )
         for k in ("A", "B")
     }


### PR DESCRIPTION
## Summary
- weight pooled TrueSkill ratings by each block's game count instead of a naïve mean
- test pooling with unequal block sizes

## Testing
- `ruff check src/farkle/run_trueskill.py tests/unit/test_run_trueskill_pooling.py`
- `black src/farkle/run_trueskill.py tests/unit/test_run_trueskill_pooling.py --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890141d5eec832f8e94058e4696bbda