### PR TITLE
Avoid repeated PDP casting and specify features keyword

### DIFF
--- a/src/farkle/run_rf.py
+++ b/src/farkle/run_rf.py
@@ -50,17 +50,20 @@ def plot_partial_dependence(model, X, column: str, out_dir: Path) -> Path:
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    # ``PartialDependenceDisplay`` currently warns if integer dtypes are passed
-    # for feature columns. Casting avoids the warning and future ``ValueError``
-    # in scikit-learn 1.9.
-    X = X.copy()
-    X[column] = X[column].astype(float)
+    # ``PartialDependenceDisplay`` warns if integer dtypes are passed for feature
+    # columns. ``X`` should therefore be cast to ``float`` before calling this
+    # function. Casting once outside this helper avoids an expensive copy for
+    # each plotted feature.
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message="Attempting to set identical low and high ylims",
         )
-        disp = PartialDependenceDisplay.from_estimator(model, X, [column])
+        disp = PartialDependenceDisplay.from_estimator(
+            model,
+            X,
+            features=[column],
+        )
     out_file = out_dir / f"pd_{column}.png"
     disp.figure_.savefig(out_file)
     plt.close(disp.figure_)

--- a/tests/unit/test_run_rf_helpers.py
+++ b/tests/unit/test_run_rf_helpers.py
@@ -5,7 +5,7 @@ from farkle.run_rf import plot_partial_dependence
 
 
 def test_plot_partial_dependence(tmp_path):
-    X = pd.DataFrame({"a": range(5), "b": range(5, 10)})
+    X = pd.DataFrame({"a": range(5), "b": range(5, 10)}).astype(float)
     y = pd.Series(range(5))
     model = HistGradientBoostingRegressor(random_state=0)
     model.fit(X, y)


### PR DESCRIPTION
## Summary
- Drop redundant cast in `plot_partial_dependence` and pass the feature name via keyword
- Adjust partial dependence test to provide float features

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68901435e6f4832f8078bda754a24864