### PR TITLE
Avoid RNG correlation in head-to-head simulations

### DIFF
--- a/src/farkle/run_bonferroni_head2head.py
+++ b/src/farkle/run_bonferroni_head2head.py
@@ -11,7 +11,7 @@ from typing import List
 import pandas as pd
 from scipy.stats import binomtest
 
-from farkle.simulation import simulate_many_games
+from farkle.simulation import simulate_many_games_from_seeds
 from farkle.stats import games_for_power
 from farkle.strategies import parse_strategy
 from farkle.utils import bonferroni_pairs
@@ -25,7 +25,8 @@ def run_bonferroni_head2head(seed: int = 0, root: Path = DEFAULT_ROOT) -> None:
     Parameters
     ----------
     seed : int, default ``0``
-        Seed for shuffling the schedule and for each simulated game.
+        Base seed for shuffling the schedule and deterministically assigning
+        unique seeds to each simulated game.
 
     The function reads ``data/tiers.json`` to find strategies in the highest
     tier.  It runs enough games for a Bonferroni-corrected binomial test on each
@@ -50,9 +51,9 @@ def run_bonferroni_head2head(seed: int = 0, root: Path = DEFAULT_ROOT) -> None:
 
     records = []
     for (a, b), grp in schedule.groupby(["a", "b"]):
-        n_games = len(grp)
-        df = simulate_many_games(
-            n_games=n_games, strategies=[parse_strategy(a), parse_strategy(b)], seed=seed, n_jobs=1
+        seeds = grp["seed"].tolist()
+        df = simulate_many_games_from_seeds(
+            seeds=seeds, strategies=[parse_strategy(a), parse_strategy(b)], n_jobs=1
         )
         wins = df["winner_strategy"].value_counts()
         wa = int(wins.get(a, 0))

--- a/tests/unit/test_run_bonferroni_head2head.py
+++ b/tests/unit/test_run_bonferroni_head2head.py
@@ -50,10 +50,12 @@ def test_run_bonferroni_head2head_writes_csv(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(rb, "parse_strategy", lambda s: s)
 
-    def fake_many_games(n_games, strategies, seed, n_jobs):
-        return pd.DataFrame({"winner_strategy": ["A"] * n_games})
+    def fake_many_games_from_seeds(*, seeds, strategies, n_jobs):
+        _ = strategies
+        _ = n_jobs
+        return pd.DataFrame({"winner_strategy": ["A"] * len(seeds)})
 
-    monkeypatch.setattr(rb, "simulate_many_games", fake_many_games)
+    monkeypatch.setattr(rb, "simulate_many_games_from_seeds", fake_many_games_from_seeds)
 
     rb.run_bonferroni_head2head(seed=0, root=data_dir)
     out_csv = data_dir / "bonferroni_pairwise.csv"
@@ -76,7 +78,9 @@ def test_run_bonferroni_head2head_single_strategy(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(rb, "parse_strategy", lambda s: s)
     monkeypatch.setattr(
-        rb, "simulate_many_games", lambda **k: pd.DataFrame({"winner_strategy": []})
+        rb,
+        "simulate_many_games_from_seeds",
+        lambda **k: pd.DataFrame({"winner_strategy": []}),
     )
 
     rb.run_bonferroni_head2head(seed=0, root=data_dir)


### PR DESCRIPTION
## Summary
- ensure each game in Bonferroni head-to-head analysis uses its own deterministic seed
- adjust unit tests to expect `simulate_many_games_from_seeds`

## Testing
- `pytest tests/unit/test_run_bonferroni_head2head.py`


------
https://chatgpt.com/codex/tasks/task_e_689014be4e04832f8bad7c4f2b99f9c1