### PR TITLE
Relax shard schema restrictions for ingest

### DIFF
--- a/src/farkle/ingest.py
+++ b/src/farkle/ingest.py
@@ -103,9 +103,12 @@ def run(cfg: PipelineCfg) -> None:
                     log.debug("Shard %s is empty — skipped", shard_path.name)
                     continue
 
-                if set(shard_df.columns) != expected_cols:
+                if not set(shard_df.columns).issubset(expected_cols):
                     log.error("Schema mismatch in %s", shard_path)
                     raise RuntimeError("Shard DataFrame columns do not match expected columns")
+
+                for col in expected_cols - set(shard_df.columns):
+                    shard_df[col] = pd.NA
 
                 shard_df = shard_df.reindex(columns=cfg.ingest_cols)
                 log.debug("Shard %s → %d rows", shard_path.name, len(shard_df))


### PR DESCRIPTION
## Summary
- allow ingesting shards with partial seat columns
- fill missing seat columns with NA and reorder to canonical layout

## Testing
- `pytest tests/unit/test_ingest_blocks.py::test_ingest_missing_seats -q` *(fails: file not found)*
- `pytest tests/unit/test_utils_functions.py::test_build_tiers_empty -q`


------
https://chatgpt.com/codex/tasks/task_e_68906a962570832fb9b35ebfe757e433