### PR TITLE
feat: add dataroot option for trueskill

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,13 @@ This project is licensed under the Apache 2.0 License.
 Run `farkle run cfg.yml` to simulate tournaments from a configuration file or use
 the API as shown above. See the unit tests and module-level docstrings for more
 examples.
+
+## TrueSkill Ratings
+Compute ratings for a directory of tournament results:
+
+```bash
+python -m farkle.run_trueskill --dataroot data/results_seed_0
+```
+
+This scans `data/results_seed_0` for blocks and writes rating files and
+`tiers.json` to `data/results_seed_0/analysis` by default.


### PR DESCRIPTION
## Summary
- allow `run_trueskill` to read result blocks from a configurable `--dataroot` directory
- default outputs to `<dataroot>/analysis` and document new CLI usage

## Testing
- `python -m farkle.run_trueskill --dataroot data/results_seed_0`
- `ls data/results_seed_0/analysis`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68906aa6d10c832fbe564f3725800ecf