### PR TITLE
feat: centralize results directory handling

### DIFF
--- a/src/farkle/analysis_config.py
+++ b/src/farkle/analysis_config.py
@@ -24,7 +24,7 @@ from typing import Sequence
 @dataclass
 class PipelineCfg:
     # 1. core paths
-    root: Path = Path("data")
+    results_dir: Path = Path("results_seed_0")
     results_glob: str = "*_players"
     analysis_subdir: str = "analysis"
     curated_rows_name: str = "game_rows.parquet"
@@ -82,7 +82,7 @@ class PipelineCfg:
     @property
     def analysis_dir(self) -> Path:
         """Directory where analysis artifacts are written."""
-        return self.root / self.analysis_subdir
+        return self.results_dir / self.analysis_subdir
 
     @property
     def data_dir(self) -> Path:
@@ -112,7 +112,14 @@ class PipelineCfg:
         subcommands).
         """
         parser = argparse.ArgumentParser(add_help=False)
-        parser.add_argument("--root", type=Path, default=Path("data"), help="Root directory")
+        parser.add_argument(
+            "--results-dir",
+            "--root",
+            dest="results_dir",
+            type=Path,
+            default=Path("results_seed_0"),
+            help="Directory containing raw results blocks",
+        )
         parser.add_argument(
             "--analysis-subdir",
             default="analysis",
@@ -120,5 +127,5 @@ class PipelineCfg:
         )
         parser.add_argument("-v", "--verbose", action="store_true", help="Enable progress bars")
         ns, remaining = parser.parse_known_args(argv)
-        cfg = cls(root=ns.root, analysis_subdir=ns.analysis_subdir)
+        cfg = cls(results_dir=ns.results_dir, analysis_subdir=ns.analysis_subdir)
         return cfg, ns, remaining

--- a/src/farkle/analytics/head2head.py
+++ b/src/farkle/analytics/head2head.py
@@ -17,6 +17,6 @@ def run(cfg: PipelineCfg) -> None:
         log.info("Head-to-Head: results up-to-date - skipped")
         return
 
-    cmd = [sys.executable, str(SCRIPT), "--root", str(cfg.root)]
+    cmd = [sys.executable, str(SCRIPT), "--root", str(cfg.results_dir)]
     log.info("Head-to-Head: calling %s", " ".join(cmd))
     subprocess.check_call(cmd)

--- a/src/farkle/analytics/rf_feat.py
+++ b/src/farkle/analytics/rf_feat.py
@@ -17,6 +17,6 @@ def run(cfg: PipelineCfg) -> None:
         log.info("Random-Forest: results up-to-date - skipped")
         return
 
-    cmd = [sys.executable, str(SCRIPT), "--root", str(cfg.root)]
+    cmd = [sys.executable, str(SCRIPT), "--root", str(cfg.results_dir)]
     log.info("Random-Forest: calling %s", " ".join(cmd))
     subprocess.check_call(cmd)

--- a/src/farkle/analytics/trueskill.py
+++ b/src/farkle/analytics/trueskill.py
@@ -18,6 +18,6 @@ def run(cfg: PipelineCfg) -> None:
         log.info("TrueSkill: results up-to-date - skipped")
         return
 
-    cmd = [sys.executable, str(SCRIPT), "--root", str(cfg.root)]
+    cmd = [sys.executable, str(SCRIPT), "--dataroot", str(cfg.results_dir)]
     log.info("TrueSkill: calling %s", " ".join(cmd))
     subprocess.check_call(cmd)

--- a/src/farkle/ingest.py
+++ b/src/farkle/ingest.py
@@ -83,7 +83,7 @@ def _fix_winner(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def run(cfg: PipelineCfg) -> None:
-    log.info("Ingest started: root=%s", cfg.root)
+    log.info("Ingest started: root=%s", cfg.results_dir)
 
     cfg.data_dir.mkdir(parents=True, exist_ok=True)
     out_path = cfg.curated_parquet
@@ -95,7 +95,7 @@ def run(cfg: PipelineCfg) -> None:
     total_rows = 0
 
     try:
-        for block in sorted(cfg.root.glob(cfg.results_glob)):
+        for block in sorted(cfg.results_dir.glob(cfg.results_glob)):
             log.info("Reading block %s", block.name)
             expected_cols = set(cfg.ingest_cols)
             for shard_df, shard_path in _iter_shards(block, cfg.ingest_cols):
@@ -135,3 +135,13 @@ def run(cfg: PipelineCfg) -> None:
         if writer:
             writer.close()
     log.info("Ingest finished — %d rows written to %s", total_rows, out_path)
+
+
+def main(argv: list[str] | None = None) -> None:  # pragma: no cover - thin CLI wrapper
+    cfg, _, _ = PipelineCfg.parse_cli(argv)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    run(cfg)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/farkle/run_bonferroni_head2head.py
+++ b/src/farkle/run_bonferroni_head2head.py
@@ -16,7 +16,7 @@ from farkle.stats import games_for_power
 from farkle.strategies import parse_strategy
 from farkle.utils import bonferroni_pairs
 
-DEFAULT_ROOT = Path("data")
+DEFAULT_ROOT = Path("results_seed_0")
 
 
 def run_bonferroni_head2head(seed: int = 0, root: Path = DEFAULT_ROOT) -> None:

--- a/src/farkle/run_full_field.py
+++ b/src/farkle/run_full_field.py
@@ -5,9 +5,10 @@ run_full_field.py  -  Phase-1 full-grid screen for all table sizes
    • Power               = 0.95    →  zβ = Φ⁻¹(0.05) ≈ 1.645
    • Detectable lift Δ   = 0.03     (3-percentage-point edge)
 
-Run with: python -m farkle.run_full_field
+Run with: ``python -m farkle.run_full_field --results-dir runs/my_run``
 """
 
+import argparse
 import multiprocessing as mp
 import shutil
 from math import ceil
@@ -67,7 +68,7 @@ def _reset_partial(out_dir: Path, n_players: int) -> None:
             ckpt.unlink()
 
 
-def main():
+def main(argv: list[str] | None = None) -> None:
     """Run tournaments for each table size defined in ``PLAYERS``.
 
     The function iterates over the configured ``PLAYERS`` list. For each
@@ -84,6 +85,15 @@ def main():
     None
     """
 
+    parser = argparse.ArgumentParser(description="Phase-1 full-grid tournament sweep")
+    parser.add_argument(
+        "--results-dir",
+        type=Path,
+        default=Path("results_seed_0"),
+        help="Directory to store tournament results",
+    )
+    args = parser.parse_args(argv or [])
+
     import farkle.run_tournament as tournament_mod  # required for main hook  # noqa: I001
 
     # ────────── GLOBAL CONFIG ─────────────────────────────────────────
@@ -94,7 +104,11 @@ def main():
     Q_FDR = 0.02  # BH, two-sided
     GLOBAL_SEED = 0
     JOBS = None  # None → all logical cores
-    BASE_OUT = Path(f"data/results_seed_{GLOBAL_SEED}")
+    BASE_OUT = args.results_dir
+    if not BASE_OUT.exists():
+        candidate = Path("data") / BASE_OUT
+        if candidate.exists():
+            BASE_OUT = candidate
     BASE_OUT.mkdir(parents=True, exist_ok=True)
     # ------------------------------------------------------------------
 
@@ -156,5 +170,6 @@ def main():
 
 
 if __name__ == "__main__":
-    # run: python -m farkle.run_full_field
-    main()
+    import sys
+
+    main(sys.argv[1:])

--- a/src/farkle/run_rf.py
+++ b/src/farkle/run_rf.py
@@ -23,7 +23,7 @@ from sklearn.inspection import PartialDependenceDisplay, permutation_importance
 # ---------------------------------------------------------------------------
 # Constants for file and directory locations used in this module
 # ---------------------------------------------------------------------------
-DEFAULT_ROOT = Path("data")
+DEFAULT_ROOT = Path("results_seed_0")
 METRICS_NAME = "metrics.parquet"
 RATINGS_NAME = "ratings_pooled.pkl"
 FIG_DIR = Path("notebooks/figs")

--- a/src/farkle/run_trueskill.py
+++ b/src/farkle/run_trueskill.py
@@ -1,10 +1,9 @@
 # src/farkle/run_trueskill.py
 """Compute TrueSkill ratings for Farkle strategies.
 
-The script scans the ``data/results`` directory for completed tournament
-blocks, updates ratings with the ``trueskill`` package and writes per-block
-as well as pooled rating files.  A ``tiers.json`` file mapping strategies to
-league tiers is also produced.
+The script scans a directory of tournament results, updates ratings with the
+``trueskill`` package and writes per-block as well as pooled rating files. A
+``tiers.json`` file mapping strategies to league tiers is also produced.
 """
 from __future__ import annotations
 
@@ -22,7 +21,7 @@ import yaml
 
 from .utils import build_tiers
 
-DEFAULT_ROOT = Path("data")
+DEFAULT_DATAROOT = Path("results_seed_0")
 
 log = logging.getLogger(__name__)
 
@@ -161,7 +160,7 @@ def _update_ratings(
 
 def run_trueskill(
     output_seed: int = 0,
-    root: Path = DEFAULT_ROOT,
+    root: Path = DEFAULT_DATAROOT,
 ) -> None:
     """Compute TrueSkill ratings for all result blocks.
 
@@ -183,7 +182,7 @@ def run_trueskill(
     """
 
     root = Path(root)
-    base = root / "results"
+    base = root / "results" if (root / "results").exists() else root
     _read_manifest_seed(base / "manifest.yaml")
     suffix = f"_seed{output_seed}" if output_seed else ""
     env = trueskill.TrueSkill()
@@ -242,11 +241,19 @@ def main(argv: list[str] | None = None) -> None:
         default=0,
         help="only used to name output files",
     )
-    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument(
+        "--dataroot",
+        "--root",
+        dest="dataroot",
+        type=Path,
+        default=DEFAULT_DATAROOT,
+    )
     args = parser.parse_args(argv or [])
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    run_trueskill(output_seed=args.output_seed, root=args.root)
+    run_trueskill(output_seed=args.output_seed, root=args.dataroot)
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add `results_dir` to `PipelineCfg` and expose via `--results-dir`
- teach ingest, analytics wrappers and CLIs to use the configured results directory
- make `run_full_field` and `run_trueskill` accept customizable output roots

## Testing
- `python -m farkle.ingest --root /tmp/empty`
- `python -m farkle.run_trueskill --dataroot /tmp/empty`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68906ac0b114832fbdaad1036b15872c