### PR TITLE
Replace random forest terminology with hist gradient boosting

### DIFF
--- a/src/farkle/analysis_config.py
+++ b/src/farkle/analysis_config.py
@@ -46,8 +46,8 @@ class PipelineCfg:
     # 3. analytics toggles / params
     run_trueskill: bool = True
     run_head2head: bool = True
-    run_rf: bool = True
-    rf_n_estimators: int = 500
+    run_hgb: bool = True
+    hgb_max_iter: int = 500
     trueskill_beta: float = 25 / 6
 
     # 4. perf

--- a/src/farkle/analytics/__init__.py
+++ b/src/farkle/analytics/__init__.py
@@ -6,7 +6,7 @@ import logging
 
 from farkle.analysis_config import PipelineCfg
 from farkle.analytics import head2head as _h2h
-from farkle.analytics import rf_feat as _rf
+from farkle.analytics import hgb_feat as _hgb
 from farkle.analytics import trueskill as _ts
 
 log = logging.getLogger(__name__)
@@ -25,8 +25,8 @@ def run_all(cfg: PipelineCfg) -> None:
     else:
         log.info("Analytics: skipping head-to-head (run_head2head=False)")
 
-    if cfg.run_rf:
-        _rf.run(cfg)
+    if cfg.run_hgb:
+        _hgb.run(cfg)
     else:
-        log.info("Analytics: skipping random forest (run_rf=False)")
+        log.info("Analytics: skipping hist gradient boosting (run_hgb=False)")
     log.info("Analytics: all modules finished")

--- a/src/farkle/analytics/hgb_feat.py
+++ b/src/farkle/analytics/hgb_feat.py
@@ -8,15 +8,15 @@ from pathlib import Path
 from farkle.analysis_config import PipelineCfg
 
 log = logging.getLogger(__name__)
-SCRIPT = Path(__file__).resolve().parents[1] / "run_rf.py"
+SCRIPT = Path(__file__).resolve().parents[1] / "run_hgb.py"
 
 
 def run(cfg: PipelineCfg) -> None:
-    out = cfg.analysis_dir / "rf_feature_importances.parquet"
+    out = cfg.results_dir / "hgb_importance.json"
     if out.exists() and out.stat().st_mtime >= cfg.curated_parquet.stat().st_mtime:
-        log.info("Random-Forest: results up-to-date - skipped")
+        log.info("Hist-Gradient-Boosting: results up-to-date - skipped")
         return
 
     cmd = [sys.executable, str(SCRIPT), "--root", str(cfg.results_dir)]
-    log.info("Random-Forest: calling %s", " ".join(cmd))
+    log.info("Hist-Gradient-Boosting: calling %s", " ".join(cmd))
     subprocess.check_call(cmd)

--- a/src/farkle/run_hgb.py
+++ b/src/farkle/run_hgb.py
@@ -1,5 +1,5 @@
-# src/farkle/run_rf.py
-"""Train a gradient boosting model to analyse strategy metrics.
+# src/farkle/run_hgb.py
+"""Train a hist gradient boosting model to analyse strategy metrics.
 
 This script reads the feature metrics and pooled ratings, fits a
 ``HistGradientBoostingRegressor`` to predict strategy ``mu`` values, then writes
@@ -70,7 +70,7 @@ def plot_partial_dependence(model, X, column: str, out_dir: Path) -> Path:
     return out_file
 
 
-def run_rf(
+def run_hgb(
     seed: int = 0,
     output_path: Path | None = None,
     root: Path = DEFAULT_ROOT,
@@ -93,7 +93,7 @@ def run_rf(
 
     Writes
     ------
-    ``<root>/rf_importance.json``
+    ``<root>/hgb_importance.json``
         JSON file mapping metric names to permutation importance scores.
     ``notebooks/figs/pd_<feature>.png``
         Partial dependence plots for each metric.
@@ -127,7 +127,7 @@ def run_rf(
         for c, s in zip(features.columns, perm_importance["importances_mean"], strict=False)
     }
     if output_path is None:
-        output_path = root / "rf_importance.json"
+        output_path = root / "hgb_importance.json"
 
     output_path.parent.mkdir(exist_ok=True)
     with output_path.open("w") as fh:
@@ -139,7 +139,7 @@ def run_rf(
 
 
 def main(argv: List[str] | None = None) -> None:
-    """Entry point for ``python -m farkle.run_rf``.
+    """Entry point for ``python -m farkle.run_hgb``.
 
     Parameters
     ----------
@@ -150,9 +150,10 @@ def main(argv: List[str] | None = None) -> None:
 
     parser = argparse.ArgumentParser(
         description=(
-            "Train a random forest using data/metrics.parquet and data/ratings_pooled.pkl. "
-            "Run from the project root. Writes rf_importance.json to --output and partial "
-            "dependence plots to notebooks/figs/."
+            "Train a HistGradientBoostingRegressor using data/metrics.parquet and "
+            "data/ratings_pooled.pkl. Run from the project root. Writes "
+            "hgb_importance.json to --output and partial dependence plots to "
+            "notebooks/figs/."
         )
     )
     parser.add_argument("--seed", type=int, default=0)
@@ -161,11 +162,11 @@ def main(argv: List[str] | None = None) -> None:
         "--output",
         type=Path,
         default=None,
-        help="Path to write rf_importance.json",
+        help="Path to write hgb_importance.json",
     )
     parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
     args = parser.parse_args(argv or [])
-    run_rf(seed=args.seed, output_path=args.output, root=args.root)
+    run_hgb(seed=args.seed, output_path=args.output, root=args.root)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_analysis_pipeline.py
+++ b/tests/unit/test_analysis_pipeline.py
@@ -43,7 +43,7 @@ def test_pipeline_all_creates_outputs(tmp_path: Path) -> None:
 
     # analytics artefacts
     assert (tmp_path / "ratings_pooled.pkl").exists()
-    assert (tmp_path / "rf_importance.json").exists()
+    assert (tmp_path / "hgb_importance.json").exists()
     figs = tmp_path / "notebooks" / "figs"
     assert any(figs.glob("pd_*.png"))
 
@@ -60,7 +60,7 @@ def test_pipeline_ingest_only(tmp_path: Path) -> None:
     analysis = tmp_path / "analysis"
     assert (analysis / "data" / "game_rows.parquet").exists()
     assert not (analysis / "metrics.parquet").exists()
-    assert not (tmp_path / "rf_importance.json").exists()
+    assert not (tmp_path / "hgb_importance.json").exists()
 
 
 def test_pipeline_missing_dependency(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_run_hgb_functionality.py
+++ b/tests/unit/test_run_hgb_functionality.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from farkle import run_rf, run_trueskill
+from farkle import run_hgb, run_trueskill
 
 
 def _setup_data(tmp_path: Path) -> Path:
@@ -23,31 +23,31 @@ def _setup_data(tmp_path: Path) -> Path:
     return data_dir
 
 
-def test_run_rf_custom_output_path(tmp_path):
+def test_run_hgb_custom_output_path(tmp_path):
     data_dir = _setup_data(tmp_path)
     out_file = data_dir / "custom.json"
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        run_rf.run_rf(output_path=out_file, root=data_dir)
+        run_hgb.run_hgb(output_path=out_file, root=data_dir)
     finally:
         os.chdir(cwd)
     assert out_file.exists()
-    assert not (data_dir / "rf_importance.json").exists()
+    assert not (data_dir / "hgb_importance.json").exists()
 
 
-def test_run_rf_importance_length_check(tmp_path, monkeypatch):
+def test_run_hgb_importance_length_check(tmp_path, monkeypatch):
     data_dir = _setup_data(tmp_path)
 
     def fake_perm_importance(_model, _X, _y, n_repeats=5, random_state=None):
         _ = n_repeats, random_state
         return {"importances_mean": np.array([0.1, 0.2])}
 
-    monkeypatch.setattr(run_rf, "permutation_importance", fake_perm_importance)
+    monkeypatch.setattr(run_hgb, "permutation_importance", fake_perm_importance)
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
         with pytest.raises(ValueError, match="Mismatch between number of features"):
-            run_rf.run_rf(output_path=data_dir / "out.json", root=data_dir)
+            run_hgb.run_hgb(output_path=data_dir / "out.json", root=data_dir)
     finally:
         os.chdir(cwd)

--- a/tests/unit/test_run_hgb_helpers.py
+++ b/tests/unit/test_run_hgb_helpers.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from sklearn.ensemble import HistGradientBoostingRegressor
 
-from farkle.run_rf import plot_partial_dependence
+from farkle.run_hgb import plot_partial_dependence
 
 
 def test_plot_partial_dependence(tmp_path):


### PR DESCRIPTION
## Summary
- rename random forest script and helpers to `run_hgb`
- update analytics pipeline to call hist gradient boosting and config flag `run_hgb`
- adjust tests and documentation for `hgb_importance.json`

## Testing
- `pytest tests/unit/test_run_hgb_functionality.py tests/unit/test_run_hgb_helpers.py tests/unit/test_analysis_pipeline.py -q`
- `pytest -q` *(fails: FileNotFoundError in run_trueskill helper tests)*

------
https://chatgpt.com/codex/tasks/task_e_6892aa167fb4832fb08d98df1a932367