### PR TITLE
Verify curated parquet schema using checksum

### DIFF
--- a/tests/unit/test_curate.py
+++ b/tests/unit/test_curate.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from farkle.analysis_config import PipelineCfg
+from farkle.curate import _already_curated, _write_manifest
+
+
+def test_already_curated_schema_checksum(tmp_path):
+    cfg = PipelineCfg(results_dir=tmp_path)
+
+    schema1 = pa.schema([("a", pa.int64())])
+    table1 = pa.Table.from_pydict({"a": [1]})
+    file1 = tmp_path / "file1.parquet"
+    pq.write_table(table1, file1)
+    manifest = tmp_path / "manifest.json"
+    _write_manifest(manifest, rows=1, schema=schema1, cfg=cfg)
+
+    assert _already_curated(file1, manifest)
+
+    schema2 = pa.schema([("b", pa.int64())])
+    table2 = pa.Table.from_pydict({"b": [1]})
+    file2 = tmp_path / "file2.parquet"
+    pq.write_table(table2, file2)
+
+    assert not _already_curated(file2, manifest)


### PR DESCRIPTION
## Summary
- add schema checksum to manifest and skip logic
- test `curate._already_curated` against schema drift

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892ab95add0832fa753089426fa7a58