### PR TITLE
refactor: run analytics modules in-process

### DIFF
--- a/src/farkle/analytics/head2head.py
+++ b/src/farkle/analytics/head2head.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import logging
-import subprocess
-import sys
-from pathlib import Path
 
+from farkle import run_bonferroni_head2head as _h2h
 from farkle.analysis_config import PipelineCfg
 
 log = logging.getLogger(__name__)
-SCRIPT = Path(__file__).resolve().parents[1] / "run_bonferroni_head2head.py"
 
 
 def run(cfg: PipelineCfg) -> None:
@@ -17,6 +14,5 @@ def run(cfg: PipelineCfg) -> None:
         log.info("Head-to-Head: results up-to-date - skipped")
         return
 
-    cmd = [sys.executable, str(SCRIPT), "--root", str(cfg.results_dir)]
-    log.info("Head-to-Head: calling %s", " ".join(cmd))
-    subprocess.check_call(cmd)
+    log.info("Head-to-Head: running in-process")
+    _h2h.main(["--root", str(cfg.results_dir)])

--- a/src/farkle/analytics/hgb_feat.py
+++ b/src/farkle/analytics/hgb_feat.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import logging
-import subprocess
-import sys
-from pathlib import Path
 
+from farkle import run_hgb as _hgb
 from farkle.analysis_config import PipelineCfg
 
 log = logging.getLogger(__name__)
-SCRIPT = Path(__file__).resolve().parents[1] / "run_hgb.py"
 
 
 def run(cfg: PipelineCfg) -> None:
@@ -17,6 +14,5 @@ def run(cfg: PipelineCfg) -> None:
         log.info("Hist-Gradient-Boosting: results up-to-date - skipped")
         return
 
-    cmd = [sys.executable, str(SCRIPT), "--root", str(cfg.results_dir)]
-    log.info("Hist-Gradient-Boosting: calling %s", " ".join(cmd))
-    subprocess.check_call(cmd)
+    log.info("Hist-Gradient-Boosting: running in-process")
+    _hgb.main(["--root", str(cfg.results_dir)])

--- a/src/farkle/analytics/trueskill.py
+++ b/src/farkle/analytics/trueskill.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import logging
-import subprocess
-import sys
-from pathlib import Path
 
+from farkle import run_trueskill as _rt
 from farkle.analysis_config import PipelineCfg
 
 log = logging.getLogger(__name__)
-SCRIPT = Path(__file__).resolve().parents[1] / "run_trueskill.py"
 
 
 def run(cfg: PipelineCfg) -> None:
@@ -18,6 +15,5 @@ def run(cfg: PipelineCfg) -> None:
         log.info("TrueSkill: results up-to-date - skipped")
         return
 
-    cmd = [sys.executable, str(SCRIPT), "--dataroot", str(cfg.results_dir)]
-    log.info("TrueSkill: calling %s", " ".join(cmd))
-    subprocess.check_call(cmd)
+    log.info("TrueSkill: running in-process")
+    _rt.main(["--dataroot", str(cfg.results_dir)])


### PR DESCRIPTION
## Summary
- avoid launching new Python processes during analytics by calling modules directly
- use in-process calls for TrueSkill, head-to-head, and HGB feature importance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b3269f68832fb8b602ba4ed4828c