### PR TITLE
Use atomic file writes for analysis outputs

### DIFF
--- a/src/farkle/run_bonferroni_head2head.py
+++ b/src/farkle/run_bonferroni_head2head.py
@@ -63,7 +63,10 @@ def run_bonferroni_head2head(seed: int = 0, root: Path = DEFAULT_ROOT) -> None:
 
     out = pd.DataFrame(records)
     pairwise_csv.parent.mkdir(exist_ok=True)
-    out.to_csv(pairwise_csv, index=False)
+
+    tmp_path = pairwise_csv.with_suffix(".tmp")
+    out.to_csv(tmp_path, index=False)
+    tmp_path.replace(pairwise_csv)
 
 
 def main(argv: List[str] | None = None) -> None:

--- a/src/farkle/run_hgb.py
+++ b/src/farkle/run_hgb.py
@@ -70,8 +70,10 @@ def plot_partial_dependence(model, X, column: str, out_dir: Path) -> Path:
             features=[column],
         )
     out_file = out_dir / f"pd_{column}.png"
-    disp.figure_.savefig(out_file)
+    tmp_file = out_file.with_suffix(".tmp")
+    disp.figure_.savefig(tmp_file, format="png")
     plt.close(disp.figure_)
+    tmp_file.replace(out_file)
     return out_file
 
 
@@ -135,8 +137,10 @@ def run_hgb(
         output_path = root / "hgb_importance.json"
 
     output_path.parent.mkdir(exist_ok=True)
-    with output_path.open("w") as fh:
+    tmp_output = output_path.with_suffix(".tmp")
+    with tmp_output.open("w") as fh:
         json.dump(imp_dict, fh, indent=2, sort_keys=True)
+    tmp_output.replace(output_path)
 
     FIG_DIR.mkdir(parents=True, exist_ok=True)
     cols = list(features.columns)


### PR DESCRIPTION
## Summary
- atomically write Bonferroni head-to-head pairwise CSVs
- save hgb importance JSON and partial dependence plots via temporary files

## Testing
- `pytest` *(fails: FileNotFoundError in trueskill helpers/pooling)*

------
https://chatgpt.com/codex/tasks/task_e_689307b2644c832fbd8d4f552ba63623