### PR TITLE
Write ingest output to raw file and finalize in curate

### DIFF
--- a/src/farkle/analysis_config.py
+++ b/src/farkle/analysis_config.py
@@ -1,13 +1,15 @@
 # farkle/analysis_config.py
 """
-Config module for the analysis stage
-# pipeline.py
-from farkle.config import PipelineCfg
-from farkle import ingest, metrics, analytics
+Config module for the analysis stage.
 
-def main():
+Typical usage::
+
+    from farkle.analysis_config import PipelineCfg
+    from farkle import ingest, curate, metrics, analytics
+
     cfg = PipelineCfg(root=Path(args.root))
-    ingest.run(cfg)
+    ingest.run(cfg)   # writes ``game_rows.raw.parquet``
+    curate.run(cfg)   # adds manifest & renames to ``game_rows.parquet``
     metrics.run(cfg)
     analytics.run_all(cfg)     # inside it: respects cfg.run_trueskill flags
 """

--- a/src/farkle/ingest.py
+++ b/src/farkle/ingest.py
@@ -83,11 +83,17 @@ def _fix_winner(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def run(cfg: PipelineCfg) -> None:
+    """Consolidate raw results blocks into a single parquet file.
+
+    The ingest step writes ``game_rows.raw.parquet`` beneath the analysis
+    directory.  A subsequent :mod:`farkle.curate` run will attach a manifest and
+    rename it to :pyattr:`cfg.curated_parquet`.
+    """
     log.info("Ingest started: root=%s", cfg.results_dir)
 
     cfg.data_dir.mkdir(parents=True, exist_ok=True)
-    out_path = cfg.curated_parquet
-    tmp_path = out_path.with_suffix(".in-progress")
+    raw_path = cfg.curated_parquet.with_suffix(".raw.parquet")
+    tmp_path = raw_path.with_suffix(".in-progress")
     if tmp_path.exists():
         tmp_path.unlink()
 
@@ -141,8 +147,8 @@ def run(cfg: PipelineCfg) -> None:
         if writer:
             writer.close()
     if tmp_path.exists():
-        tmp_path.replace(out_path)
-    log.info("Ingest finished — %d rows written to %s", total_rows, out_path)
+        tmp_path.replace(raw_path)
+    log.info("Ingest finished — %d rows written to %s", total_rows, raw_path)
 
 
 def main(argv: list[str] | None = None) -> None:  # pragma: no cover - thin CLI wrapper

--- a/tests/unit/test_analysis_pipeline.py
+++ b/tests/unit/test_analysis_pipeline.py
@@ -38,6 +38,7 @@ def test_pipeline_all_creates_outputs(tmp_path: Path) -> None:
 
     analysis = tmp_path / "analysis"
     assert (analysis / "data" / "game_rows.parquet").exists()
+    assert not (analysis / "data" / "game_rows.raw.parquet").exists()
     assert (analysis / "metrics.parquet").exists()
     assert (analysis / "seat_advantage.csv").exists()
 
@@ -58,7 +59,10 @@ def test_pipeline_ingest_only(tmp_path: Path) -> None:
         os.chdir(cwd)
 
     analysis = tmp_path / "analysis"
-    assert (analysis / "data" / "game_rows.parquet").exists()
+    raw = analysis / "data" / "game_rows.raw.parquet"
+    curated = analysis / "data" / "game_rows.parquet"
+    assert raw.exists()
+    assert not curated.exists()
     assert not (analysis / "metrics.parquet").exists()
     assert not (tmp_path / "hgb_importance.json").exists()
 


### PR DESCRIPTION
## Summary
- write ingest output to game_rows.raw.parquet so curate can finalize atomically
- have curate read the raw parquet, write a manifest, then replace it with the curated file
- document the revised pipeline flow and adjust pipeline tests

## Testing
- `pytest tests/unit/test_curate.py tests/unit/test_analysis_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68931306b540832fb4cf3aa551d7841b