### PR TITLE
Sort legacy shard paths for deterministic ingest

### DIFF
--- a/src/farkle/ingest.py
+++ b/src/farkle/ingest.py
@@ -28,7 +28,7 @@ def _iter_shards(block: Path, cols: tuple[str, ...]):
     # Legacy layout with `<Np_rows>` directory containing shards
     row_dirs = [p for p in block.glob("*_rows") if p.is_dir()]
     if row_dirs:
-        for shard_path in row_dirs[0].glob("*.parquet"):
+        for shard_path in sorted(row_dirs[0].glob("*.parquet")):
             yield pd.read_parquet(shard_path, columns=list(cols)), shard_path
     else:  # compact parquet or CSV
         for pqt in block.glob("*.parquet"):


### PR DESCRIPTION
## Summary
- ensure legacy shard files are processed in deterministic order during ingest

## Testing
- `pytest` *(fails: FileNotFoundError in trueskill helpers/pooling tests)*

------
https://chatgpt.com/codex/tasks/task_e_689313459894832f8d9c05d0a696dff1