### PR TITLE
Use analysis dir for trueskill and head2head outputs

### DIFF
--- a/src/farkle/analytics/head2head.py
+++ b/src/farkle/analytics/head2head.py
@@ -9,10 +9,10 @@ log = logging.getLogger(__name__)
 
 
 def run(cfg: PipelineCfg) -> None:
-    out = cfg.analysis_dir / "bonferroni.parquet"
+    out = cfg.analysis_dir / "bonferroni_pairwise.csv"
     if out.exists() and out.stat().st_mtime >= cfg.curated_parquet.stat().st_mtime:
         log.info("Head-to-Head: results up-to-date - skipped")
         return
 
     log.info("Head-to-Head: running in-process")
-    _h2h.main(["--root", str(cfg.results_dir)])
+    _h2h.main(["--root", str(cfg.analysis_dir)])

--- a/src/farkle/analytics/trueskill.py
+++ b/src/farkle/analytics/trueskill.py
@@ -10,10 +10,15 @@ log = logging.getLogger(__name__)
 
 def run(cfg: PipelineCfg) -> None:
     """Thin wrapper around the legacy script so the new pipeline stays small."""
-    out = cfg.analysis_dir / "trueskill.parquet"
+    out = cfg.analysis_dir / "tiers.json"
     if out.exists() and out.stat().st_mtime >= cfg.curated_parquet.stat().st_mtime:
         log.info("TrueSkill: results up-to-date - skipped")
         return
 
     log.info("TrueSkill: running in-process")
-    _rt.main(["--dataroot", str(cfg.results_dir)])
+    _rt.main([
+        "--dataroot",
+        str(cfg.results_dir),
+        "--root",
+        str(cfg.analysis_dir),
+    ])


### PR DESCRIPTION
## Summary
- adjust trueskill analytics wrapper to look for tiers.json and pass explicit dataroot/root
- update head-to-head analytics wrapper to expect bonferroni_pairwise.csv in analysis directory

## Testing
- `pytest -q`
  - failing tests: run_trueskill helper tests missing expected rating files


------
https://chatgpt.com/codex/tasks/task_e_6893156bbefc832fb1533429f692d93a