### PR TITLE
Fix TrueSkill CLI dataroot default and lazy-load heavy modules

### DIFF
--- a/src/farkle/run_trueskill.py
+++ b/src/farkle/run_trueskill.py
@@ -265,13 +265,13 @@ def main(argv: list[str] | None = None) -> None:
         help="appended to filenames to avoid overwrites",
     )
     parser.add_argument(
-    "--dataroot",
-    type=Path,
-    default=DEFAULT_DATAROOT,
-    help=(
-        "Folder that holds <N>_players blocks "
-        "(default: <repo>/data/results_seed_0). "
-        "Accepts absolute or relative paths."
+        "--dataroot",
+        type=Path,
+        default=None,
+        help=(
+            "Folder that holds <N>_players blocks "
+            "(default: <root>/results or <repo>/data/results). "
+            "Accepts absolute or relative paths."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- avoid importing heavy engine modules on `farkle` package import by lazily loading them only on access
- ensure `run_trueskill` CLI derives results directory from `--root` when `--dataroot` isn't supplied

## Testing
- `pytest tests/unit/test_run_trueskill_pooling.py::test_pooled_ratings_are_weighted_mean -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_68931e506cf8832fb1a7de6dd81bb543