### PR TITLE
chore: resolve type warnings in tests

### DIFF
--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -1,4 +1,5 @@
 from math import ceil, sqrt
+from typing import Any
 
 import pytest
 from scipy.stats import norm
@@ -22,7 +23,7 @@ from farkle.stats import games_for_power
     ],
 )
 def test_games_for_power_invalid(params):
-    base = {"n_strategies": 2}
+    base: dict[str, Any] = {"n_strategies": 2}
     base.update(params)
     with pytest.raises(ValueError):
         games_for_power(**base)


### PR DESCRIPTION
## Summary
- fix Pylance false positives in tournament worker tests with explicit casts
- allow invalid-parameter tests to use a typed dict

## Testing
- `pytest tests/unit/test_run_tournament.py::test_play_one_shuffle_collects tests/unit/test_run_tournament.py::test_run_chunk_metrics_queue tests/unit/test_stats.py::test_games_for_power_invalid -q`

------
https://chatgpt.com/codex/tasks/task_e_6893c917ea30832fb162ed227b642181