### PR TITLE
Enable multiprocessing for head-to-head analysis

### DIFF
--- a/src/farkle/analytics/head2head.py
+++ b/src/farkle/analytics/head2head.py
@@ -15,4 +15,11 @@ def run(cfg: PipelineCfg) -> None:
         return
 
     log.info("Head-to-Head: running in-process")
-    _h2h.main(["--root", str(cfg.analysis_dir)])
+    _h2h.main(
+        [
+            "--root",
+            str(cfg.analysis_dir),
+            "--jobs",
+            str(cfg.n_jobs),
+        ]
+    )


### PR DESCRIPTION
## Summary
- allow `run_bonferroni_head2head` to run simulations in parallel via `n_jobs`
- thread through multiprocessing option to CLI and analytics pipeline
- exercise new option in tests

## Testing
- `ruff check src/farkle/run_bonferroni_head2head.py src/farkle/analytics/head2head.py tests/unit/test_run_bonferroni_head2head.py`
- `black src/farkle/run_bonferroni_head2head.py src/farkle/analytics/head2head.py tests/unit/test_run_bonferroni_head2head.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e12174e0832f836740849f92e292