### PR TITLE
Handle temp importance JSON on failure

### DIFF
--- a/src/farkle/run_hgb.py
+++ b/src/farkle/run_hgb.py
@@ -138,9 +138,13 @@ def run_hgb(
 
     output_path.parent.mkdir(exist_ok=True)
     tmp_output = output_path.with_suffix(".tmp")
-    with tmp_output.open("w") as fh:
-        json.dump(imp_dict, fh, indent=2, sort_keys=True)
-    tmp_output.replace(output_path)
+    try:
+        with tmp_output.open("w") as fh:
+            json.dump(imp_dict, fh, indent=2, sort_keys=True)
+        tmp_output.replace(output_path)
+    except Exception:
+        tmp_output.unlink(missing_ok=True)
+        raise
 
     FIG_DIR.mkdir(parents=True, exist_ok=True)
     cols = list(features.columns)

--- a/tests/unit/test_run_hgb_functionality.py
+++ b/tests/unit/test_run_hgb_functionality.py
@@ -49,5 +49,6 @@ def test_run_hgb_importance_length_check(tmp_path, monkeypatch):
     try:
         with pytest.raises(ValueError, match="Mismatch between number of features"):
             run_hgb.run_hgb(output_path=data_dir / "out.json", root=data_dir)
+        assert not (data_dir / "out.tmp").exists()
     finally:
         os.chdir(cwd)


### PR DESCRIPTION
## Summary
- ensure temporary permutation importance JSON files are removed when errors occur
- add test asserting stale temp files aren't left behind

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e3ad8b50832fbd91b0de3b6f367e