### PR TITLE
feat(pipeline): enable debug logging with verbose

### DIFF
--- a/src/farkle/analysis_config.py
+++ b/src/farkle/analysis_config.py
@@ -128,7 +128,14 @@ class PipelineCfg:
             default="analysis",
             help="Subdirectory for analysis outputs",
         )
-        parser.add_argument("-v", "--verbose", action="store_true", help="Enable progress bars")
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            action="store_true",
+            help="Enable progress bars and DEBUG logging",
+        )
         ns, remaining = parser.parse_known_args(argv)
         cfg = cls(results_dir=ns.results_dir, analysis_subdir=ns.analysis_subdir)
+        if ns.verbose:
+            cfg.log_level = "DEBUG"
         return cfg, ns, remaining

--- a/src/farkle/pipeline.py
+++ b/src/farkle/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 from typing import Callable, Sequence
 
@@ -21,6 +22,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     args = parser.parse_args(remaining)
     verbose = getattr(cli_ns, "verbose", False)
+
+    logging.basicConfig(
+        level=getattr(logging, cfg.log_level.upper(), logging.INFO),
+        format="%(message)s",
+        force=True,
+    )
 
     if args.command == "ingest":
         try:


### PR DESCRIPTION
## Summary
- use the verbose flag to bump log level to DEBUG
- initialize pipeline logging according to cfg.log_level

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e4120598832fbb3d530da5af9e2f