### PR TITLE
Seed default TrueSkill ratings for all strategies

### DIFF
--- a/tests/unit/test_run_trueskill_helpers.py
+++ b/tests/unit/test_run_trueskill_helpers.py
@@ -120,7 +120,10 @@ def test_update_ratings_ranked():
         ratings[p[0]], ratings[p[1]] = new[0][0], new[1][0]
 
     expected = {k: rt.RatingStats(r.mu, r.sigma) for k, r in ratings.items()}
-    assert result == expected
+    assert set(result) == {"A", "B", "C"}
+    assert result["A"] == expected["A"]
+    assert result["B"] == expected["B"]
+    assert result["C"] == rt.RatingStats(rt.DEFAULT_RATING.mu, rt.DEFAULT_RATING.sigma)
 
 
 def test_load_ranked_games_empty(tmp_path):

--- a/tests/unit/test_run_trueskill_pooling.py
+++ b/tests/unit/test_run_trueskill_pooling.py
@@ -71,13 +71,14 @@ def test_pooled_ratings_are_weighted_mean(tmp_path):
     expected3 = run_trueskill._update_ratings(g3, ["A", "B"], env)
 
     w2, w3 = len(g2), len(g3)
-    expected_pooled = {
-        k: run_trueskill.RatingStats(
-            (expected2[k].mu * w2 + expected3[k].mu * w3) / (w2 + w3),
-            (expected2[k].sigma * w2 + expected3[k].sigma * w3) / (w2 + w3),
+    expected_pooled = {}
+    for k in ("A", "B", "C"):
+        e2 = expected2.get(k, run_trueskill.RatingStats(run_trueskill.DEFAULT_RATING.mu, run_trueskill.DEFAULT_RATING.sigma))
+        e3 = expected3.get(k, run_trueskill.RatingStats(run_trueskill.DEFAULT_RATING.mu, run_trueskill.DEFAULT_RATING.sigma))
+        expected_pooled[k] = run_trueskill.RatingStats(
+            (e2.mu * w2 + e3.mu * w3) / (w2 + w3),
+            (e2.sigma * w2 + e3.sigma * w3) / (w2 + w3),
         )
-        for k in ("A", "B")
-    }
 
     assert r2 == expected2
     assert r3 == expected3


### PR DESCRIPTION
## Summary
- Ensure every strategy starts with the same default TrueSkill rating
- Seed ratings for all strategies before processing games
- Update tests to expect seeded default ratings and adjusted pooling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893e4821de0832fb56bd00341fa93d1