### PR TITLE
Refactor curation for dynamic schema hash

### DIFF
--- a/tests/unit/test_curate.py
+++ b/tests/unit/test_curate.py
@@ -1,23 +1,39 @@
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from farkle.analysis_config import PipelineCfg
+from farkle.analysis_config import PipelineCfg, expected_schema_for
 from farkle.curate import _already_curated, _write_manifest
 
 
-def test_already_curated_schema_checksum(tmp_path):
+def test_already_curated_schema_hash(tmp_path):
     cfg = PipelineCfg(results_dir=tmp_path)
 
-    schema1 = pa.schema([("a", pa.int64())])
-    table1 = pa.Table.from_pydict({"a": [1]})
+    schema0 = expected_schema_for(0)
+    table1 = pa.table(
+        {
+            "winner": ["P1"],
+            "winner_seat": ["1"],
+            "winning_score": [100],
+            "n_rounds": [1],
+        },
+        schema=schema0,
+    )
     file1 = tmp_path / "file1.parquet"
     pq.write_table(table1, file1)
     manifest = tmp_path / "manifest.json"
-    _write_manifest(manifest, rows=1, schema=schema1, cfg=cfg)
+    _write_manifest(manifest, rows=1, schema=schema0, cfg=cfg)
 
     assert _already_curated(file1, manifest)
 
-    table2 = pa.Table.from_pydict({"b": [1]})
+    table2 = pa.table(
+        {
+            "winner": ["P1"],
+            "winner_seat": ["1"],
+            "winning_score": [100],
+            "n_rounds": [1],
+            "P1_score": [100],
+        }
+    )
     file2 = tmp_path / "file2.parquet"
     pq.write_table(table2, file2)
 


### PR DESCRIPTION
## Summary
- compute manifest schema hash from canonical analysis schema per player count
- validate parquet via `schema_hash`, logging mismatches
- update curate tests for the new schema hash logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml', numba, scipy, hypothesis, etc.)*
- `/root/.pyenv/shims/pytest tests/unit/test_curate.py -q`
- `/root/.pyenv/shims/pytest tests/unit/test_analysis_config_git_sha.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894117ea2b4832fbe1c5f5d37f9eb9a