### PR TITLE
Improve pipeline logging and config handling

### DIFF
--- a/src/farkle/analysis_config.py
+++ b/src/farkle/analysis_config.py
@@ -55,7 +55,7 @@ class PipelineCfg:
     trueskill_beta: float = 25 / 6
 
     # 4. perf
-    cores = os.cpu_count() or 1  # or however many the user wants
+    cores = os.cpu_count()
     if cores is None:
         raise RuntimeError("Unable to determine CPU Count")
     n_jobs: int = max(cores - 1, 1)

--- a/src/farkle/pipeline.py
+++ b/src/farkle/pipeline.py
@@ -23,11 +23,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(remaining)
     verbose = getattr(cli_ns, "verbose", False)
 
-    logging.basicConfig(
-        level=getattr(logging, cfg.log_level.upper(), logging.INFO),
-        format="%(message)s",
-        force=True,
-    )
+    log_kwargs = {
+        "level": getattr(logging, cfg.log_level.upper(), logging.INFO),
+        "format": "%(message)s",
+        "force": True,
+    }
+    if cfg.log_file is not None:
+        log_kwargs["handlers"] = [
+            logging.StreamHandler(),
+            logging.FileHandler(cfg.log_file),
+        ]
+    logging.basicConfig(**log_kwargs)
 
     if args.command == "ingest":
         try:


### PR DESCRIPTION
## Summary
- allow pipeline to log to an optional file in addition to stdout
- simplify CPU core detection in analysis configuration

## Testing
- `pytest tests/unit/test_run_hgb_helpers.py tests/unit/test_stats.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml', 'numba', 'pyarrow', 'hypothesis', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6894157e3c2c832f80ba5d2048a20198