### PR TITLE
Ensure verbose logging sets debug level

### DIFF
--- a/src/farkle/pipeline.py
+++ b/src/farkle/pipeline.py
@@ -23,8 +23,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(remaining)
     verbose = getattr(cli_ns, "verbose", False)
 
+    # Ensure DEBUG level is in effect before any sub-modules log
+    effective_level = logging.DEBUG if verbose else getattr(
+        logging, cfg.log_level.upper(), logging.INFO
+    )
     log_kwargs = {
-        "level": getattr(logging, cfg.log_level.upper(), logging.INFO),
+        "level": effective_level,
         "format": "%(message)s",
         "force": True,
     }


### PR DESCRIPTION
## Summary
- ensure verbose CLI uses DEBUG logging before submodules run

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml' and others)*

------
https://chatgpt.com/codex/tasks/task_e_689450997ac8832fa2a7da1c632bc305