### PR TITLE
Handle empty Bonferroni schedule gracefully

### DIFF
--- a/src/farkle/run_bonferroni_head2head.py
+++ b/src/farkle/run_bonferroni_head2head.py
@@ -54,6 +54,11 @@ def run_bonferroni_head2head(*, seed: int = 0, root: Path = DEFAULT_ROOT, n_jobs
     games_needed = games_for_power(len(elites), method="bonferroni", full_pairwise=True)
     schedule = bonferroni_pairs(elites, games_needed, seed)
 
+    # Nothing to simulate (e.g., only one elite strategy)
+    if schedule.empty:
+        print("\u2713 Bonferroni H2H: no games needed \u2014 exiting early.")
+        return
+
     records = []
     for (a, b), grp in schedule.groupby(["a", "b"]):
         seeds = grp["seed"].tolist()
@@ -65,7 +70,8 @@ def run_bonferroni_head2head(*, seed: int = 0, root: Path = DEFAULT_ROOT, n_jobs
         wins = df["winner_strategy"].value_counts()
         wa = int(wins.get(a, 0))
         wb = int(wins.get(b, 0))
-        pval = binomtest(wa, wa + wb).pvalue
+        # One-sided: "A beats B"
+        pval = binomtest(wa, wa + wb, alternative="greater").pvalue
         records.append({"a": a, "b": b, "wins_a": wa, "wins_b": wb, "pvalue": pval})
 
     out = pd.DataFrame(records)

--- a/tests/unit/test_run_bonferroni_head2head.py
+++ b/tests/unit/test_run_bonferroni_head2head.py
@@ -65,7 +65,7 @@ def test_run_bonferroni_head2head_writes_csv(tmp_path, monkeypatch):
     assert set(df.columns) == {"a", "b", "wins_a", "wins_b", "pvalue"}
 
 
-def test_run_bonferroni_head2head_single_strategy(tmp_path, monkeypatch):
+def test_run_bonferroni_head2head_single_strategy(tmp_path, monkeypatch, capsys):
     """Gracefully handle tiers.json with only one strategy."""
 
     data_dir = tmp_path / "data"
@@ -88,9 +88,11 @@ def test_run_bonferroni_head2head_single_strategy(tmp_path, monkeypatch):
     )
 
     rb.run_bonferroni_head2head(seed=0, root=data_dir)
+    captured = capsys.readouterr().out
+    assert "no games needed" in captured
+
     out_csv = data_dir / "bonferroni_pairwise.csv"
-    assert out_csv.exists()
-    assert out_csv.read_text() == "\n"
+    assert not out_csv.exists()
 
 
 def test_run_bonferroni_head2head_missing_file(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Exit early when Bonferroni H2H schedule is empty.
- Use one-sided binomial test when evaluating matches.
- Update tests for early exit behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689450a55ca0832fb9bef57403216660