### PR TITLE
refactor: remove max_shard_mb option

### DIFF
--- a/src/farkle/analysis_config.py
+++ b/src/farkle/analysis_config.py
@@ -44,8 +44,7 @@ class PipelineCfg:
         )
     )
     parquet_codec: str = "zstd"
-    row_group_size: int = 64_000
-    max_shard_mb: int = 512
+    row_group_size: int = 64_000  # max_shard_mb removed (unused)
 
     # 3. analytics toggles / params
     run_trueskill: bool = True


### PR DESCRIPTION
## Summary
- remove unused max_shard_mb option from PipelineCfg

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689450bcd9f0832fbfded96b93b454cf