### PR TITLE
Support per-player ingest outputs and expand schema

### DIFF
--- a/src/farkle/analysis_config.py
+++ b/src/farkle/analysis_config.py
@@ -31,7 +31,7 @@ class PipelineCfg:
     results_dir: Path = Path("results_seed_0")
     results_glob: str = "*_players"
     analysis_subdir: str = "analysis"
-    curated_rows_name: str = "game_rows.parquet"
+    curated_rows_name: str = "game_rows.parquet"  # legacy single-file name
     metrics_name: str = "metrics.parquet"
 
     # 2. ingest
@@ -62,16 +62,15 @@ class PipelineCfg:
 
     # 5. logging & provenance
     log_level: str = "INFO"
-    log_file: Path | None = None           # e.g. Path("analysis/pipeline.log")
+    log_file: Path | None = None  # e.g. Path("analysis/pipeline.log")
     manifest_name: str = "manifest.json"
     _git_sha: str | None = field(default=None, repr=False, init=False)
 
     def _load_git_sha(self) -> str:
         try:
             import subprocess
-            return subprocess.check_output(
-                        ["git", "rev-parse", "HEAD"], text=True
-                        ).strip()
+
+            return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
         except Exception:
             return "unknown _load_git_sha() exception"
 
@@ -92,6 +91,18 @@ class PipelineCfg:
     def data_dir(self) -> Path:
         """Subdirectory beneath :pyattr:`analysis_dir` holding intermediate data."""
         return self.analysis_dir / "data"
+
+    # New: per-N ingested rows (raw + curated)
+    def ingested_rows_raw(self, n_players: int) -> Path:
+        sub = self.data_dir / f"{n_players}p"
+        sub.mkdir(parents=True, exist_ok=True)
+        return sub / f"{n_players}p_ingested_rows.raw.parquet"
+
+    def ingested_rows_curated(self, n_players: int) -> Path:
+        return (self.data_dir / f"{n_players}p") / f"{n_players}p_ingested_rows.parquet"
+
+    def manifest_for(self, n_players: int) -> Path:
+        return (self.data_dir / f"{n_players}p") / f"manifest_{n_players}p.json"
 
     @property
     def curated_parquet(self) -> Path:
@@ -144,37 +155,39 @@ class PipelineCfg:
 
 # ---------- static pieces -------------------------------------------------
 _BASE_FIELDS: Final[list[tuple[str, pa.DataType]]] = [
-    ("winner",        pa.string()),
-    ("winner_seat",   pa.string()),
+    ("winner", pa.string()),
+    ("winner_seat", pa.string()),  # P{n} label of the winner
+    ("winner_strategy", pa.string()),  # strategy string of the winner
+    ("seat_ranks", pa.list_(pa.string())),  # ["P7","P1","P3",...]
     ("winning_score", pa.int32()),
-    ("n_rounds",      pa.int16()),
+    ("n_rounds", pa.int16()),
 ]
 
 _SEAT_TEMPLATE: Final[dict[str, pa.DataType]] = {
-    "score"          : pa.int32(),
-    "farkles"        : pa.int16(),
-    "rolls"          : pa.int16(),
-    "highest_turn"   : pa.int16(),
-    "strategy"       : pa.string(),
-    "rank"           : pa.int8(),
-    "loss_margin"    : pa.int32(),
+    "score": pa.int32(),
+    "farkles": pa.int16(),
+    "rolls": pa.int16(),
+    "highest_turn": pa.int16(),
+    "strategy": pa.string(),
+    "rank": pa.int8(),
+    "loss_margin": pa.int32(),
     "smart_five_uses": pa.int16(),
     "n_smart_five_dice": pa.int16(),
-    "smart_one_uses" : pa.int16(),
+    "smart_one_uses": pa.int16(),
     "n_smart_one_dice": pa.int16(),
-    "hot_dice"       : pa.bool_(),
+    "hot_dice": pa.int16(),  # counts of hot-dice used this game
     # add/remove seat-level cols here once
 }
 
 # ---------- public helpers -----------------------------------------------
 
+
 def expected_schema_for(n_players: int) -> pa.Schema:
-    """Return canonical Arrow schema for a given player count."""
-    seat_fields = [
-        (f"P{p}_{suffix}", typ)
-        for p in range(1, n_players + 1)
-        for suffix, typ in _SEAT_TEMPLATE.items()
-    ]
+    """Return the canonical schema for *n_players* seats."""
+    seat_fields: list[pa.Field] = []
+    for i in range(1, n_players + 1):
+        for suffix, dtype in _SEAT_TEMPLATE.items():
+            seat_fields.append(pa.field(f"P{i}_{suffix}", dtype))
     return pa.schema(_BASE_FIELDS + seat_fields)
 
 

--- a/tests/unit/test_curate.py
+++ b/tests/unit/test_curate.py
@@ -13,6 +13,8 @@ def test_already_curated_schema_hash(tmp_path):
         {
             "winner": ["P1"],
             "winner_seat": ["1"],
+            "winner_strategy": ["none"],
+            "seat_ranks": [[]],
             "winning_score": [100],
             "n_rounds": [1],
         },


### PR DESCRIPTION
## Summary
- add helpers for per-player ingested row files and manifests
- extend game schema with winner metadata and hot dice counts
- update curation tests for new schema fields

## Testing
- `ruff check src/farkle/analysis_config.py`
- `ruff check tests/unit/test_curate.py`
- `black src/farkle/analysis_config.py`
- `black tests/unit/test_curate.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68954d3a6f0c832fa12e3314a13d9c21