### PR TITLE
Add aggregate step to analysis pipeline

### DIFF
--- a/src/farkle/analysis_config.py
+++ b/src/farkle/analysis_config.py
@@ -106,7 +106,10 @@ class PipelineCfg:
 
     @property
     def curated_parquet(self) -> Path:
-        return self.analysis_dir / "data" / self.curated_rows_name
+        legacy = self.analysis_dir / "data" / self.curated_rows_name
+        combined = self.data_dir / "all_n_players_combined" / "all_ingested_rows.parquet"
+        # Prefer aggregated superset if present; fallback to legacy path
+        return combined if combined.exists() or not legacy.exists() else legacy
       
     def to_json(self) -> str:
         return json.dumps(self, default=lambda o: str(o) if isinstance(o, Path) else o, indent=2)

--- a/src/farkle/pipeline.py
+++ b/src/farkle/pipeline.py
@@ -7,7 +7,7 @@ from typing import Callable, Sequence
 
 from tqdm import tqdm
 
-from farkle import analytics, curate, ingest, metrics
+from farkle import analytics, curate, ingest, metrics, aggregate
 from farkle.analysis_config import PipelineCfg
 
 
@@ -17,7 +17,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(prog="farkle-analyze")
     sub = parser.add_subparsers(dest="command", required=True)
-    for name in ("ingest", "curate", "metrics", "analytics", "all"):
+    for name in ("ingest", "curate", "aggregate", "metrics", "analytics", "all"):
         sub.add_parser(name)
 
     args = parser.parse_args(remaining)
@@ -51,6 +51,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         except Exception as e:  # noqa: BLE001
             print(f"curate step failed: {e}", file=sys.stderr)
             return 1
+    elif args.command == "aggregate":
+        try:
+            aggregate.run(cfg)
+        except Exception as e:  # noqa: BLE001
+            print(f"aggregate step failed: {e}", file=sys.stderr)
+            return 1
     elif args.command == "metrics":
         try:
             metrics.run(cfg)
@@ -67,6 +73,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         steps: list[tuple[str, Callable[[PipelineCfg], None]]] = [
             ("ingest", ingest.run),
             ("curate", curate.run),
+            ("aggregate", aggregate.run),
             ("metrics", metrics.run),
             ("analytics", analytics.run_all),
         ]


### PR DESCRIPTION
## Summary
- integrate aggregate stage into pipeline CLI and `all` workflow
- prefer aggregated ingested rows for downstream metrics/analytics
- test new aggregate command and updated file layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895541e1de0832f863bb66dd5580478