### PR TITLE
test: expand pipeline CLI coverage

### DIFF
--- a/tests/unit/test_analysis_pipeline.py
+++ b/tests/unit/test_analysis_pipeline.py
@@ -1,9 +1,13 @@
 import os
 from pathlib import Path
+import argparse
+import logging
 
 import numpy as np
 import pandas as pd
 import pytest
+
+from farkle.analysis_config import PipelineCfg
 
 pipeline = pytest.importorskip("pipeline")
 
@@ -101,3 +105,70 @@ def test_pipeline_missing_dependency(tmp_path: Path, monkeypatch: pytest.MonkeyP
             pipeline.main(["all", "--root", str(tmp_path)])
     finally:
         os.chdir(cwd)
+
+
+@pytest.mark.parametrize(
+    "command,target",
+    [
+        ("ingest", "farkle.ingest.run"),
+        ("curate", "farkle.curate.run"),
+        ("aggregate", "farkle.aggregate.run"),
+        ("metrics", "farkle.metrics.run"),
+        ("analytics", "farkle.analytics.run_all"),
+    ],
+)
+def test_individual_step_failure_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    target: str,
+) -> None:
+    log_file = tmp_path / "pipeline.log"
+
+    def _boom(cfg: PipelineCfg) -> None:  # noqa: ARG001
+        logging.getLogger().debug("running %s", command)
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(target, _boom)
+
+    def _parse_cli(cls, argv):
+        parser = argparse.ArgumentParser(add_help=False)
+        parser.add_argument("--root", dest="results_dir", type=Path, default=tmp_path)
+        parser.add_argument("-v", "--verbose", action="store_true")
+        parser.add_argument("--log-file", type=Path)
+        ns, remaining = parser.parse_known_args(argv)
+        cfg = PipelineCfg(results_dir=ns.results_dir)
+        cfg.log_file = ns.log_file
+        if ns.verbose:
+            cfg.log_level = "DEBUG"
+        return cfg, ns, remaining
+
+    monkeypatch.setattr(PipelineCfg, "parse_cli", classmethod(_parse_cli))
+
+    rc = pipeline.main(
+        [command, "--root", str(tmp_path), "--verbose", "--log-file", str(log_file)]
+    )
+    assert rc == 1
+    assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
+    assert log_file.exists()
+    assert f"running {command}" in log_file.read_text()
+
+
+def test_pipeline_all_step_failure_prints_and_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _ok(cfg: PipelineCfg) -> None:  # noqa: ARG001
+        return None
+
+    def _boom(cfg: PipelineCfg) -> None:  # noqa: ARG001
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("farkle.ingest.run", _ok)
+    monkeypatch.setattr("farkle.curate.run", _ok)
+    monkeypatch.setattr("farkle.aggregate.run", _boom)
+
+    with pytest.raises(RuntimeError):
+        pipeline.main(["all", "--root", str(tmp_path)])
+
+    err = capsys.readouterr().err
+    assert "aggregate step failed: boom" in err


### PR DESCRIPTION
## Summary
- add parameterized tests covering individual pipeline subcommands when they raise errors
- verify verbose flag sets debug logging and writes to log files
- ensure 'all' command surfaces failing step message and exception

## Testing
- `pytest tests/unit/test_analysis_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ab3861a48832f8bdb6bdc22c3c032