### PR TITLE
Eliminate deprecated datetime and PyArrow usage

### DIFF
--- a/src/farkle/aggregate.py
+++ b/src/farkle/aggregate.py
@@ -41,7 +41,7 @@ def run(cfg: PipelineCfg) -> None:
     out = out_dir / "all_ingested_rows.parquet"
     tmp = out.with_suffix(out.suffix + ".in-progress")
 
-    all_tbl = pa.concat_tables(parts, promote=True)
+    all_tbl = pa.concat_tables(parts, promote_options="default")
     pq.write_table(all_tbl, tmp, compression=cfg.parquet_codec, use_dictionary=True)
     tmp.replace(out)
     log.info("aggregate: wrote %s (%d rows)", out, total)

--- a/src/farkle/curate.py
+++ b/src/farkle/curate.py
@@ -5,7 +5,7 @@ import hashlib
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -47,7 +47,9 @@ def _write_manifest(manifest_path: Path, *, rows: int, schema: pa.Schema, cfg: P
         "codec": cfg.parquet_codec,
         "row_group_size": cfg.row_group_size,
         "git_sha": cfg.git_sha,
-        "created": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "created": datetime.now(UTC)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
         "pid": str(os.getpid()),
     }
     manifest_path.write_text(json.dumps(payload, indent=2))


### PR DESCRIPTION
## Summary
- use timezone-aware `datetime.now(UTC)` when generating manifest timestamps
- switch `pa.concat_tables` to `promote_options="default"`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ac4328d6c832fb630b6a1307353bf