### PR TITLE
Expand default round limit for games

### DIFF
--- a/src/farkle/engine.py
+++ b/src/farkle/engine.py
@@ -430,7 +430,7 @@ class FarkleGame:
         self.table_seed = table_seed
 
     # ---------------------------- gameplay -----------------------------
-    def play(self, max_rounds: int = 50) -> GameMetrics:
+    def play(self, max_rounds: int = 200) -> GameMetrics:
         """Execute the game loop and return final statistics.
 
         Inputs

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -237,3 +237,18 @@ def test_take_turn_roll_limit(monkeypatch):
 
     assert p.n_rolls == ROLL_LIMIT + 1
 
+
+def test_game_stops_at_default_max_rounds(monkeypatch):
+    """Ensure the game loop honours the default 200-round cap."""
+
+    def bust_roll(self, n):
+        self.n_rolls += 1
+        return [2, 3, 4, 6, 2, 3][:n]
+
+    monkeypatch.setattr(FarklePlayer, "_roll", bust_roll)
+
+    players = [FarklePlayer("A", AlwaysRoll()), FarklePlayer("B", AlwaysRoll())]
+    gm = FarkleGame(players, target_score=10_000).play()
+
+    assert gm.game.n_rounds == 200
+


### PR DESCRIPTION
## Summary
- Allow games to continue for up to 200 rounds by default
- Keep per-turn roll fuse at 1000 rolls
- Add regression test ensuring 200-round default is respected

## Testing
- `pytest tests/unit/test_engine.py::test_game_stops_at_default_max_rounds -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f95bc89a4832f9df5a345bad72529