### PR TITLE
Fix seat wins type mismatch in metrics

### DIFF
--- a/src/farkle/metrics.py
+++ b/src/farkle/metrics.py
@@ -177,8 +177,8 @@ def run(cfg: PipelineCfg) -> None:
 
     # wins per seat (from aggregate parquet)
     ds_all = ds.dataset(data_file, format="parquet")
-    wins_by_seat = {
-        i: ds_all.count_rows(filter=(ds.field("winner") == f"P{i}"))
+    seat_wins: dict[int, int] = {
+        i: int(ds_all.count_rows(filter=(ds.field("winner") == f"P{i}")))
         for i in range(1, 13)
     }
 
@@ -188,7 +188,7 @@ def run(cfg: PipelineCfg) -> None:
         w.writerow(["seat", "wins", "games_with_seat", "win_rate"])
         for i in range(1, 13):
             games = denom[i]
-            wins = int(wins_by_seat[i] or 0)
+            wins = seat_wins.get(i, 0)
             rate = (wins / games) if games else 0.0
             w.writerow([i, wins, games, rate])
 


### PR DESCRIPTION
## Summary
- prevent Counter type mismatch by storing seat wins in a typed dictionary
- use `dict.get` to look up seat win counts when writing seat advantage CSV

## Testing
- `pytest -q` *(fails: test_iter_shards_consolidated, test_fix_winner_with_ranks, test_fix_winner_without_ranks, test_run_schema_mismatch_logs_and_closes, test_partial_dependence_warning_and_limit, test_read_row_shards, test_read_winners_csv, test_read_loose_parquets, test_load_ranked_games_parquet, test_load_ranked_games_rank_based, test_load_ranked_games_csv, test_load_ranked_games_multi_row_dirs, test_load_ranked_games_empty, test_load_ranked_games_missing_strategy, test_run_trueskill_incomplete_block, test_run_trueskill_with_suffix, test_pooled_ratings_are_weighted_mean)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f3ee0a54832f931ab6d7d1925eb5