### PR TITLE
Add invariant checks for analytics pipeline

### DIFF
--- a/src/farkle/aggregate.py
+++ b/src/farkle/aggregate.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from farkle.analysis_config import PipelineCfg, expected_schema_for
+from farkle.checks import check_post_aggregate
 
 log = logging.getLogger("aggregate")
 
@@ -71,3 +72,4 @@ def run(cfg: PipelineCfg) -> None:
         raise RuntimeError("aggregate: output schema mismatch")
 
     log.info("aggregate: wrote %s (%d rows)", out, total)
+    check_post_aggregate(files, out)

--- a/src/farkle/checks.py
+++ b/src/farkle/checks.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
+
+from .analysis_config import expected_schema_for
+
+log = logging.getLogger(__name__)
+
+
+def check_pre_metrics(combined_parquet: Path, winner_col: str = "winner") -> None:
+    """Assert winner column exists, no negative counters, row counts match manifests.
+
+    Parameters
+    ----------
+    combined_parquet:
+        Path to the aggregated parquet produced by :mod:`aggregate`.
+    winner_col:
+        Name of the column holding the winner label.
+    """
+    if not combined_parquet.exists():
+        raise RuntimeError(f"check_pre_metrics: missing {combined_parquet}")
+
+    schema = pq.read_schema(combined_parquet)
+    if winner_col not in schema.names:
+        raise RuntimeError(
+            f"check_pre_metrics: missing '{winner_col}' column in {combined_parquet}"
+        )
+
+    dataset = ds.dataset(combined_parquet, format="parquet")
+    neg_cols: list[str] = []
+    for field in schema:
+        if pa.types.is_integer(field.type) and field.name != "loss_margin":
+            if dataset.count_rows(filter=ds.field(field.name) < 0) > 0:
+                neg_cols.append(field.name)
+    if neg_cols:
+        raise RuntimeError(
+            f"check_pre_metrics: negative values present in {', '.join(neg_cols)}"
+        )
+
+    data_dir = (
+        combined_parquet.parent.parent
+        if combined_parquet.parent.name == "all_n_players_combined"
+        else combined_parquet.parent
+    )
+    manifests = sorted(data_dir.glob("*p/manifest_*p.json"))
+    if not manifests:
+        raise RuntimeError(
+            f"check_pre_metrics: no manifest files found under {data_dir}"
+        )
+    manifest_rows = 0
+    for m in manifests:
+        try:
+            meta = json.loads(m.read_text())
+            manifest_rows += int(meta.get("row_count", 0))
+        except Exception as e:  # noqa: BLE001
+            raise RuntimeError(f"check_pre_metrics: failed to parse {m}: {e}") from e
+
+    combined_rows = dataset.count_rows()
+    if combined_rows != manifest_rows:
+        raise RuntimeError(
+            "check_pre_metrics: row-count mismatch "
+            f"{combined_rows} != {manifest_rows}"
+        )
+
+    log.info("✓ check_pre_metrics OK")
+
+
+def check_post_aggregate(
+    curated_files: list[Path],
+    combined_parquet: Path,
+    max_players: int = 12,
+) -> None:
+    """Assert sum(rows per N) == combined rows; schema has P1..P12 templates."""
+    if not combined_parquet.exists():
+        raise RuntimeError(f"check_post_aggregate: missing {combined_parquet}")
+
+    try:
+        combined_pf = pq.ParquetFile(combined_parquet)
+    except Exception as e:  # noqa: BLE001
+        raise RuntimeError(
+            f"check_post_aggregate: unable to read {combined_parquet}: {e}"
+        ) from e
+    combined_rows = combined_pf.metadata.num_rows
+
+    total_rows = 0
+    for f in curated_files:
+        try:
+            total_rows += pq.ParquetFile(f).metadata.num_rows
+        except Exception as e:  # noqa: BLE001
+            raise RuntimeError(f"check_post_aggregate: unable to read {f}: {e}") from e
+    if combined_rows != total_rows:
+        raise RuntimeError(
+            "check_post_aggregate: row-count mismatch "
+            f"{combined_rows} != {total_rows}"
+        )
+
+    expected = expected_schema_for(max_players).names
+    actual = pq.read_schema(combined_parquet).names
+    if actual != expected:
+        raise RuntimeError("check_post_aggregate: output schema mismatch")
+
+    log.info("✓ check_post_aggregate OK")


### PR DESCRIPTION
## Summary
- introduce `check_pre_metrics` and `check_post_aggregate` to validate parquet inputs and outputs
- verify row counts and schemas during aggregate and metrics steps and log success
- use `winner_seat` for seat win counts and run pre-metrics checks before metrics calculations

## Testing
- `pytest tests/unit/test_analysis_pipeline.py::test_pipeline_all_creates_outputs -q` *(fails: A load persistent id instruction was encountered, but no persistent_load function was specified)*

------
https://chatgpt.com/codex/tasks/task_e_68be558b1ce0832fb12a27e177418800