### PR TITLE
feat: load analysis config from YAML

### DIFF
--- a/configs/presets/full.yaml
+++ b/configs/presets/full.yaml
@@ -1,0 +1,25 @@
+experiment:
+  name: full_2025_09_07
+  seed: 42
+io:
+  results_dir: results/exp_full_2025_09_07
+  analysis_subdir: analysis
+ingest:
+  row_group_size: 262144
+  n_jobs: 3
+aggregate:
+  max_players: 12
+metrics:
+  seat_range: [1, 12]
+trueskill:
+  beta: 25.0
+  tau: 0.1
+  draw_probability: 0.0
+head2head:
+  n_jobs: 8
+  games_per_pair: 20000
+  fdr_q: 0.02
+hgb:
+  max_depth: 6
+  n_estimators: 300
+schema_version: 1

--- a/src/farkle/curate.py
+++ b/src/farkle/curate.py
@@ -44,6 +44,7 @@ def _write_manifest(
         "row_count": rows,
         "schema_hash": schema_hash,
         "compression": cfg.parquet_codec,
+        "config_sha": getattr(cfg, "config_sha", None),
         "created_at": datetime.now(UTC)
         .isoformat(timespec="seconds")
         .replace("+00:00", "Z"),

--- a/src/farkle/ingest.py
+++ b/src/farkle/ingest.py
@@ -1,6 +1,7 @@
 # src/farkle/ingest.py
 from __future__ import annotations
 
+import argparse
 import logging
 import re
 from concurrent.futures import ProcessPoolExecutor
@@ -15,6 +16,7 @@ import pyarrow.parquet as pq
 from farkle.analysis_config import (
     PipelineCfg,
     expected_schema_for,
+    load_config,
 )
 
 log = logging.getLogger(__name__)
@@ -224,9 +226,14 @@ def run(cfg: PipelineCfg) -> None:
 
 
 def main(argv: list[str] | None = None) -> None:  # pragma: no cover - thin CLI wrapper
-    cfg, _, _ = PipelineCfg.parse_cli(argv)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config", type=Path, default=Path("analysis_config.yaml"), help="Path to YAML config"
+    )
+    args = parser.parse_args(argv)
+    cfg, _ = load_config(Path(args.config))
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    run(cfg)
+    run(cfg.to_pipeline_cfg())
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- add Pydantic models for analysis settings and YAML loader with SHA hashing
- load YAML configs in pipeline CLI, persisting resolved config and SHA manifest
- include config hash in curate manifests and ship example preset

## Testing
- `pytest tests/unit/test_analysis_config_git_sha.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be55bf166c832fa926dfc2088b3452