### PR TITLE
feat: add config-driven tournament runner

### DIFF
--- a/src/farkle/simulation/run_tournament.py
+++ b/src/farkle/simulation/run_tournament.py
@@ -10,7 +10,6 @@ row.  A parquet dump of all rows can also be requested via --row-dir.
 
 from __future__ import annotations
 
-import argparse
 import contextlib
 import logging
 import multiprocessing as mp
@@ -30,7 +29,6 @@ import pyarrow.parquet as pq
 
 from farkle.simulation.simulation import _play_game, generate_strategy_grid
 from farkle.simulation.strategies import ThresholdStrategy
-from farkle.utils.logging_utils import setup_info_logging, setup_warning_logging
 
 log = logging.getLogger(__name__)
 
@@ -566,67 +564,3 @@ def run_tournament(
 # ---------------------------------------------------------------------------
 
 
-def main() -> None:
-    mp.set_start_method("spawn", force=True)
-
-    p = argparse.ArgumentParser(description="Run a Monte-Carlo Farkle tournament")
-    p.add_argument("--seed", type=int, default=0, help="global RNG seed")
-    p.add_argument("--checkpoint", type=Path, default="checkpoint.pkl", help="pickle output")
-    p.add_argument("--jobs", type=int, default=None, help="worker processes")
-    p.add_argument("--ckpt-sec", type=int, default=CKPT_EVERY_SEC, help="seconds between saves")
-    p.add_argument(
-        "--metrics",
-        action="store_true",
-        help="collect per-strategy means/variances",
-    )
-    p.add_argument(
-        "--num-shuffles",
-        type=int,
-        default=NUM_SHUFFLES,
-        help="number of shuffles to simulate",
-    )
-    p.add_argument(
-        "--row-dir",
-        type=Path,
-        metavar="DIR",
-        help="write full per-game rows to DIR as parquet",
-    )
-    p.add_argument(
-        "--metric-chunk-dir",
-        type=Path,
-        metavar="DIR",
-        help="write per-chunk metric aggregates to DIR",
-    )
-    p.add_argument(
-        "--log_level",
-        choices=["DEBUG", "INFO", "WARNING"],
-        default="INFO",
-        help="logging verbosity",
-    )
-    args = p.parse_args()
-
-    cfg = TournamentConfig(
-        num_shuffles=NUM_SHUFFLES,
-        desired_sec_per_chunk=DESIRED_SEC_PER_CHUNK,
-        ckpt_every_sec=args.ckpt_sec,
-    )
-
-    if args.log_level == "INFO":
-        setup_info_logging()
-    else:
-        setup_warning_logging()
-
-    run_tournament(
-        config=cfg,
-        global_seed=args.seed,
-        checkpoint_path=args.checkpoint,
-        n_jobs=args.jobs,
-        collect_metrics=args.metrics,
-        row_output_directory=args.row_dir,
-        metric_chunk_directory=args.metric_chunk_dir,
-        num_shuffles=args.num_shuffles,
-    )
-
-
-if __name__ == "__main__":  # pragma: no cover
-    main()

--- a/src/farkle/simulation/runner.py
+++ b/src/farkle/simulation/runner.py
@@ -1,0 +1,118 @@
+"""High level tournament runner using configuration objects.
+
+The :func:`run_tournament` function acts as a thin wrapper around the
+lower level helpers found in :mod:`farkle.simulation.run_tournament`.
+It accepts an :class:`AppConfig` instance which mirrors the structure
+used throughout the project.  Only a tiny subset of the original
+configuration surface is supported – just enough for the unit tests –
+but additional fields can be added in the future without touching the
+public API.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator
+
+from farkle.simulation.run_tournament import (
+    TournamentConfig,
+    _init_worker,
+    _play_shuffle,
+    generate_strategy_grid,
+)
+from farkle.utils import parallel, sinks
+
+
+# ---------------------------------------------------------------------------
+# Configuration containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SimConfig:
+    """Simulation related settings.
+
+    Attributes
+    ----------
+    jobs:
+        Number of worker processes. ``None`` lets the executor decide.
+    seed:
+        Master RNG seed.  Individual worker seeds are derived from it.
+    n_games:
+        Total number of games to simulate.  The number is rounded up so that
+        all strategies get an equal number of appearances.
+    checkpoints:
+        Unused placeholder for future extension; kept for compatibility with
+        earlier iterations of the project.
+    n_players:
+        Number of players in each simulated game.
+    """
+
+    jobs: int | None = None
+    seed: int = 0
+    n_games: int = 0
+    checkpoints: int | None = None
+    n_players: int = 5
+
+
+@dataclass
+class IOConfig:
+    """Simple container for I/O paths."""
+
+    results_dir: Path = Path("results")
+
+
+@dataclass
+class AppConfig:
+    """Top level configuration passed to :func:`run_tournament`."""
+
+    sim: SimConfig = field(default_factory=SimConfig)
+    io: IOConfig = field(default_factory=IOConfig)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_tournament(cfg: AppConfig) -> int:
+    """Run a Farkle tournament according to ``cfg``.
+
+    The function executes a Monte-Carlo tournament by repeatedly invoking
+    :func:`farkle.simulation.run_tournament._play_shuffle`.  Results are
+    aggregated into a ``strategy → wins`` counter which is persisted as a CSV
+    file inside ``cfg.io.results_dir``.  A best-effort integer describing the
+    number of games played is returned.
+    """
+
+    strategies, _ = generate_strategy_grid()
+    tcfg = TournamentConfig(n_players=cfg.sim.n_players)
+
+    games_per_shuffle = tcfg.games_per_shuffle
+    if games_per_shuffle <= 0:
+        raise ValueError("games_per_shuffle must be positive")
+
+    # round up to the next whole shuffle so that each strategy participates
+    n_shuffles = max(1, -(-cfg.sim.n_games // games_per_shuffle))
+
+    seeds = parallel.spawn_worker_seeds(cfg.sim.seed, n_shuffles)
+
+    win_totals: Counter[str] = Counter()
+    for wins in parallel.process_map(
+        _play_shuffle,
+        seeds,
+        n_jobs=cfg.sim.jobs,
+        initializer=_init_worker,
+        initargs=(strategies, tcfg, None),
+    ):
+        win_totals.update(wins)
+
+    out_dir = cfg.io.results_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    sinks.write_counter_csv(win_totals, out_dir / "win_counts.csv")
+
+    return n_shuffles * games_per_shuffle
+
+
+__all__ = ["AppConfig", "SimConfig", "IOConfig", "run_tournament"]

--- a/src/farkle/simulation/time_farkle.py
+++ b/src/farkle/simulation/time_farkle.py
@@ -7,7 +7,6 @@ Prints timing for a single game and for a batch of N games
 using random ThresholdStrategy instances for each player.
 """
 
-import argparse
 import random
 import time
 
@@ -20,90 +19,26 @@ from farkle.simulation.simulation import (
 from farkle.simulation.strategies import ThresholdStrategy, random_threshold_strategy
 
 
-def _positive_int(value: str) -> int:
-    """Return ``value`` as ``int`` if it is strictly positive."""
-
-    ivalue = int(value)
-    if ivalue <= 0:
-        raise argparse.ArgumentTypeError("must be a positive integer")
-    return ivalue
-
-
-def build_arg_parser() -> argparse.ArgumentParser:
-    """Return the :class:`argparse.ArgumentParser` for the CLI."""
-    parser = argparse.ArgumentParser(
-        description="Time one Farkle game and a batch of N games.",
-    )
-    parser.add_argument(
-        "-n",
-        "--n_games",
-        type=_positive_int,
-        default=1000,
-        help="Number of games to simulate in batch",
-    )
-    parser.add_argument(
-        "-p",
-        "--players",
-        type=_positive_int,
-        default=5,
-        help="Number of players per game",
-    )
-    parser.add_argument(
-        "-s",
-        "--seed",
-        type=_positive_int,
-        default=42,
-        help="Master seed for reproducible RNG",
-    )
-    parser.add_argument(
-        "-j",
-        "--jobs",
-        type=_positive_int,
-        default=1,
-        help="Number of parallel processes",
-    )
-    return parser
-
-
 def make_random_strategies(num_players: int, seed: int | None) -> list[ThresholdStrategy]:
-    """Generate random strategies for each player.
+    """Generate random strategies for each player."""
 
-    Args:
-        num_players: Number of players in the game.
-        seed: Seed for deterministic randomness.
-
-    Returns:
-        list[ThresholdStrategy]:
-            Randomly generated ``ThresholdStrategy`` objects.
-    """
     rng = random.Random(seed)
     return [random_threshold_strategy(rng) for _ in range(num_players)]
 
 
-def measure_sim_times(argv: list[str] | None = None):
+def measure_sim_times(
+    *, n_games: int = 1000, players: int = 5, seed: int = 42, jobs: int = 1
+) -> None:
     """Run timing benchmarks for one game and a batch of games.
 
-    Args:
-        argv: Optional argument list to parse instead of ``sys.argv``.
-
-    Returns:
-        None
+    The function keeps the original printed output but no longer parses
+    command-line arguments.  All parameters are supplied directly.
     """
-    parser = build_arg_parser()
-    if argv and any(arg.startswith("--") for arg in argv):
-        try:
-            args = parser.parse_args(argv)
-        except SystemExit as exc:
-            raise argparse.ArgumentTypeError(str(exc)) from exc
-    else:
-        args = parser.parse_args(argv)
 
-    # 1) Build a fixed roster of random strategies
-    strategies = make_random_strategies(args.players, args.seed)
+    strategies = make_random_strategies(players, seed)
 
-    # 2) Time a single game
     t0 = time.perf_counter()
-    gm = simulate_one_game(strategies=strategies, seed=args.seed)
+    gm = simulate_one_game(strategies=strategies, seed=seed)
     t1 = time.perf_counter()
     print("\nSingle game:")
     print(f"  Time elapsed      : {t1 - t0:.6f} s")
@@ -112,21 +47,15 @@ def measure_sim_times(argv: list[str] | None = None):
     print(f"  Winning score     : {gm.players[winner].score}")
     print(f"  Rounds            : {gm.game.n_rounds}")
 
-    # 3) Time a batch of N games
     t0 = time.perf_counter()
     df: pd.DataFrame = simulate_many_games(
-        n_games=args.n_games, strategies=strategies, seed=args.seed, n_jobs=args.jobs
+        n_games=n_games, strategies=strategies, seed=seed, n_jobs=jobs
     )
     t1 = time.perf_counter()
-    print(f"\nBatch of {args.n_games} games (jobs={args.jobs}):")
+    print(f"\nBatch of {n_games} games (jobs={jobs}):")
     print(f"  Time elapsed      : {t1 - t0:.6f} s")
     print("  Winners breakdown :")
     print(df["winner"].value_counts().to_string())
 
 
-def main():
-    measure_sim_times()
-
-
-if __name__ == "__main__":
-    main()
+__all__ = ["measure_sim_times", "make_random_strategies"]

--- a/src/farkle/utils/parallel.py
+++ b/src/farkle/utils/parallel.py
@@ -1,0 +1,61 @@
+"""Parallel execution helpers used by simulations.
+
+This module centralises small utilities for spawning deterministic
+random seeds and running work in a :class:`ProcessPoolExecutor`.
+The helpers are intentionally lightweight so unit tests can patch or
+stub them easily.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from typing import Callable, Iterable, Iterator, Sequence, TypeVar
+
+import numpy as np
+
+T = TypeVar("T")
+
+
+def spawn_worker_seeds(seed: int, n: int) -> list[int]:
+    """Return ``n`` 32-bit seeds derived from ``seed``.
+
+    The function relies on :func:`numpy.random.default_rng` to generate a
+    reproducible sequence of unsigned 32-bit integers that can be used as
+    independent seeds for worker processes.
+    """
+
+    rng = np.random.default_rng(seed)
+    return rng.integers(0, 2**32 - 1, size=n, dtype=np.uint32).tolist()
+
+
+def process_map(
+    fn: Callable[[T], T] | Callable[[T], object],
+    items: Sequence[T],
+    *,
+    n_jobs: int | None = None,
+    initializer: Callable[..., object] | None = None,
+    initargs: Sequence[object] | None = None,
+) -> Iterator[object]:
+    """Yield ``fn(item)`` for each *item* using a process pool.
+
+    Parameters
+    ----------
+    fn:
+        Callable executed in the worker processes.
+    items:
+        Work items passed one by one to ``fn``.
+    n_jobs:
+        Maximum number of worker processes. ``None`` lets
+        :class:`ProcessPoolExecutor` decide based on the CPU count.
+    initializer, initargs:
+        Forwarded to :class:`ProcessPoolExecutor` to allow initialisation of
+        per-process state.
+    """
+
+    if initargs is None:
+        initargs = ()
+    with ProcessPoolExecutor(
+        max_workers=n_jobs, initializer=initializer, initargs=tuple(initargs)
+    ) as pool:
+        futures = [pool.submit(fn, item) for item in items]
+        for fut in as_completed(futures):
+            yield fut.result()

--- a/src/farkle/utils/sinks.py
+++ b/src/farkle/utils/sinks.py
@@ -1,0 +1,34 @@
+"""Output helpers for simulation results.
+
+The :mod:`farkle.simulation.runner` uses these functions to persist
+aggregated results.  The helpers keep all file system interactions in a
+single place which simplifies testing.
+"""
+from __future__ import annotations
+
+import csv
+from collections import Counter
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+def write_counter_csv(counter: Counter[str], path: Path) -> None:
+    """Write ``counter`` to ``path`` as ``strategy,wins`` CSV."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["strategy", "wins"])
+        for strat, wins in counter.items():
+            writer.writerow([strat, wins])
+
+
+def write_parquet_rows(rows: Iterable[Mapping[str, object]], path: Path) -> None:
+    """Write a sequence of dictionaries to ``path`` as a parquet file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pylist(list(rows))
+    pq.write_table(table, path)


### PR DESCRIPTION
## Summary
- introduce `farkle.simulation.runner` exposing `run_tournament(cfg: AppConfig)`
- extract worker seed and process pool helpers to `farkle.utils.parallel`
- add csv/parquet sink helpers in `farkle.utils.sinks`
- drop CLI plumbing from simulation utilities

## Testing
- `pytest tests/unit/simulation/test_run_tournament.py::test_run_chunk_counts_games -q`
- `pytest -q` *(fails: No module named 'hypothesis', 'pydantic', 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_68c501f74fd4832fa9d7aca12b80a4fb