### PR TITLE
Refactor CLI entry point and clean up legacy scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,7 @@ viz   = ["plotly>=5.21", "panel>=1.4", "dask[dataframe]>=2024.5"]
 docs  = ["mkdocs-material>=9.5", "mkdocstrings[python]>=0.24"]
 
 [project.scripts]
-farkle = "farkle.farkle_cli:main"
-time-farkle = "farkle.time_farkle:main"
-run-full-field = "farkle.run_full_field:main"
-watch-game = "farkle.watch_game:watch_game"
-farkle-analyze = "farkle.pipeline:main"
+farkle = "farkle.cli.main:main"
 
 # ── 3. Tell Hatchling where the code lives ───────────
 [tool.hatch.build.targets.wheel]

--- a/src/farkle/__main__.py
+++ b/src/farkle/__main__.py
@@ -2,16 +2,16 @@
 """Command line entry point for the :mod:`farkle` package.
 
 When executed as ``python -m farkle`` this module simply delegates to
-:func:`farkle.farkle_cli.main` which implements the full CLI logic.
+:func:`farkle.cli.main.main` which implements the full CLI logic.
 """
 
 from __future__ import annotations
 
-from farkle.cli.farkle_cli import main as cli_main
+from farkle.cli.main import main as cli_main
 
 
 def main() -> None:
-    """Invoke :func:`farkle.farkle_cli.main`."""
+    """Invoke :func:`farkle.cli.main.main`."""
 
     cli_main()
 

--- a/src/farkle/cli/main.py
+++ b/src/farkle/cli/main.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for the Farkle CLI.
+
+Exports the :func:`main` entry point from :mod:`farkle.cli.farkle_cli` so
+``pyproject.toml`` can reference ``farkle.cli.main:main``.
+"""
+
+from __future__ import annotations
+
+from .farkle_cli import load_config, main
+
+__all__ = ["load_config", "main"]

--- a/tests/unit/cli/test_main_module.py
+++ b/tests/unit/cli/test_main_module.py
@@ -8,7 +8,7 @@ def test_main_module_calls_cli(monkeypatch):
         nonlocal called
         called = True
 
-    monkeypatch.setattr("farkle.cli.farkle_cli.main", fake_main)
+    monkeypatch.setattr("farkle.cli.main.main", fake_main)
     runpy.run_module("farkle", run_name="__main__")
 
     assert called

--- a/tests/unit/utils/test_utilities.py
+++ b/tests/unit/utils/test_utilities.py
@@ -8,7 +8,7 @@ import pytest
 import yaml
 
 import farkle.utils.farkle_io as farkle_io
-from farkle.cli import farkle_cli  # imports the module, not the exe
+import farkle.cli.main as cli_main  # imports the module, not the exe
 from farkle.simulation.stats import games_for_power
 from farkle.simulation.strategies import ThresholdStrategy
 from farkle.utils.farkle_io import simulate_many_games_stream
@@ -43,7 +43,7 @@ def test_cli_run(tmp_path, monkeypatch):
     cfg_path.write_text(yaml.safe_dump(cfg))
 
     monkeypatch.setattr(sys, "argv", ["farkle", "run", str(cfg_path)])
-    farkle_cli.main()
+    cli_main.main()
 
     assert Path(cfg["sim"]["out_csv"]).exists()
 
@@ -189,7 +189,7 @@ def test_cli_missing_file(monkeypatch):
     bad = "nope.yml"
     monkeypatch.setattr(sys, "argv", ["farkle", "run", bad])
     with pytest.raises(FileNotFoundError):
-        farkle_cli.main()
+        cli_main.main()
 
 
 def test_cli_bad_yaml(tmp_path, monkeypatch):
@@ -197,7 +197,7 @@ def test_cli_bad_yaml(tmp_path, monkeypatch):
     cfg.write_text("{:")  # invalid YAML
     monkeypatch.setattr(sys, "argv", ["farkle", "run", str(cfg)])
     with pytest.raises(yaml.YAMLError):
-        farkle_cli.main()
+        cli_main.main()
 
 
 def test_cli_missing_keys(tmp_path, monkeypatch):
@@ -205,25 +205,25 @@ def test_cli_missing_keys(tmp_path, monkeypatch):
     cfg.write_text(yaml.safe_dump({}))
     monkeypatch.setattr(sys, "argv", ["farkle", "run", str(cfg)])
     with pytest.raises(KeyError):
-        farkle_cli.main()
+        cli_main.main()
 
 
 def test_load_config_missing_file(tmp_path):
     cfg_path = tmp_path / "missing.yml"
     with pytest.raises(FileNotFoundError):
-        farkle_cli.load_config(str(cfg_path))
+        cli_main.load_config(str(cfg_path))
 
 
 def test_load_config_bad_yaml(tmp_path):
     cfg_path = tmp_path / "bad.yml"
     cfg_path.write_text("strategy_grid: [")
     with pytest.raises(yaml.YAMLError):
-        farkle_cli.load_config(str(cfg_path))
+        cli_main.load_config(str(cfg_path))
 
 
 def test_load_config_missing_keys(tmp_path):
     cfg_path = tmp_path / "cfg.yml"
     cfg_path.write_text(yaml.safe_dump({"strategy_grid": {}}))
     with pytest.raises(KeyError) as excinfo:
-        farkle_cli.load_config(str(cfg_path))
+        cli_main.load_config(str(cfg_path))
     assert "sim" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- remove legacy console scripts
- point the `farkle` command at `farkle.cli.main:main`
- add thin wrapper module for new CLI entry point

## Testing
- `pytest` *(fails: ModuleNotFoundError and FileNotFoundError for analysis modules; 41 failed, 392 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c502172c94832f977be30f5b948845