### PR TITLE
Refactor tournament parallelism

### DIFF
--- a/src/farkle/utils/random.py
+++ b/src/farkle/utils/random.py
@@ -24,7 +24,7 @@ def spawn_seeds(n: int, *, seed: int | None = None) -> np.ndarray:
     """
 
     rng = make_rng(seed)
-    return rng.integers(0, MAX_UINT32, size=n, dtype=np.uint32).tolist()
+    return rng.integers(0, MAX_UINT32, size=n, dtype=np.uint32)
 
 
 __all__ = ["MAX_UINT32", "make_rng", "spawn_seeds"]


### PR DESCRIPTION
## Summary
- Generate all RNG seeds with `utils.random.spawn_seeds`
- Remove central row writer by writing per-shuffle parquet shards with manifest entries
- Execute tournament chunks via `utils.parallel.process_map`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'simulate_many_games_stream')*


------
https://chatgpt.com/codex/tasks/task_e_68c782f7ffb4832fb79d1ea6234e4ccb