### PR TITLE
Use Parquet for metric chunk temp files

### DIFF
--- a/tests/unit/simulation/test_run_tournament.py
+++ b/tests/unit/simulation/test_run_tournament.py
@@ -525,7 +525,7 @@ def test_run_tournament_metric_chunking(monkeypatch, tmp_path):
         num_shuffles=2,
     )
 
-    files = sorted(metric_dir.glob("metrics_*.pkl"))
+    files = sorted(metric_dir.glob("metrics_*.parquet"))
     assert len(files) == 2
     for m in rt.METRIC_LABELS:
         assert captured["sums"][m]["S"] == 2.0


### PR DESCRIPTION
## Summary
- serialize per-chunk tournament metrics as Parquet instead of pickle
- adjust tests for new metrics chunk format

## Testing
- `pytest tests/unit/simulation/test_run_tournament.py::test_run_tournament_metric_chunking tests/unit/simulation/test_run_tournament_metrics.py::test_row_writer_flushes_and_shuts_down`

------
https://chatgpt.com/codex/tasks/task_e_68c783af6c10832fa47ad875c68a463a