### PR TITLE
Use centralized RNG utilities for deterministic behavior

### DIFF
--- a/src/farkle/game/engine.py
+++ b/src/farkle/game/engine.py
@@ -12,8 +12,8 @@ High-level flow
   scoring, and consulting its strategy.
 
 The module keeps no global state; randomness lives inside each
-FarklePlayer via its dedicated random.Random instance (passed in
-from the outer simulation layer).
+FarklePlayer via its dedicated :class:`numpy.random.Generator` instance
+(passed in from the outer simulation layer).
 """
 
 from __future__ import annotations
@@ -26,6 +26,7 @@ import numpy as np
 
 from farkle.game.scoring import DiceRoll, default_score
 from farkle.simulation.strategies import ThresholdStrategy
+from farkle.utils.random import make_rng
 
 __all__ = [
     "FarklePlayer",
@@ -52,7 +53,7 @@ class FarklePlayer:
     strategy: ThresholdStrategy
     score: int = 0
     has_scored: bool = False  # entered game (≥500) flag
-    rng: np.random.Generator = field(default_factory=np.random.default_rng, repr=False)
+    rng: np.random.Generator = field(default_factory=make_rng, repr=False)
 
     # counters
     n_farkles: int = 0

--- a/src/farkle/simulation/watch_game.py
+++ b/src/farkle/simulation/watch_game.py
@@ -19,7 +19,7 @@ import random
 from dataclasses import asdict
 from types import MethodType
 
-import numpy as np
+from farkle.utils.random import make_rng, spawn_seeds
 
 from farkle.game.engine import FarkleGame, FarklePlayer
 from farkle.game.scoring import default_score
@@ -178,14 +178,16 @@ def watch_game(seed: int | None = None) -> None:
     Parameters
     ----------
     seed:
-        Optional seed forwarded to ``numpy.random.default_rng`` to make the game
-        deterministic.
+        Optional seed forwarded to :func:`farkle.utils.random.make_rng` to make
+        the game deterministic.
     """
-    rng = np.random.default_rng(seed)
+    strategy_seed1, strategy_seed2, player_seed1, player_seed2 = spawn_seeds(
+        4, seed=seed
+    )
 
     # --- make two random strategies -------------------------------------
-    strategy1 = random_threshold_strategy(random.Random(int(rng.integers(2**32))))
-    strategy2 = random_threshold_strategy(random.Random(int(rng.integers(2**32))))
+    strategy1 = random_threshold_strategy(random.Random(strategy_seed1))
+    strategy2 = random_threshold_strategy(random.Random(strategy_seed2))
     log.info("P1 strategy\n%s\n", strategy_yaml(strategy1))
     log.info("P2 strategy\n%s\n", strategy_yaml(strategy2))
 
@@ -199,12 +201,12 @@ def watch_game(seed: int | None = None) -> None:
         p1 = TracePlayer(
             "P1",
             strategy1,
-            rng=np.random.default_rng(rng.integers(2**32)),
+            rng=make_rng(player_seed1),
         )
         p2 = TracePlayer(
             "P2",
             strategy2,
-            rng=np.random.default_rng(rng.integers(2**32)),
+            rng=make_rng(player_seed2),
         )
 
         game = FarkleGame([p1, p2], target_score=10_000)


### PR DESCRIPTION
## Summary
- Use `farkle.utils.random.make_rng` for player RNG in engine
- Drive `watch_game` seeding via `farkle.utils.random.spawn_seeds` and `make_rng`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis'; ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c78677aa4c832fa0bdce5a0fd61386