### PR TITLE
Expose metrics options in configs and CLI

### DIFF
--- a/src/farkle/cli/main.py
+++ b/src/farkle/cli/main.py
@@ -65,7 +65,17 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # run
-    sub.add_parser("run", help="Run a tournament")
+    run_parser = sub.add_parser("run", help="Run a tournament")
+    run_parser.add_argument(
+        "--metrics",
+        action="store_true",
+        help="Collect per-strategy metrics in addition to win counts",
+    )
+    run_parser.add_argument(
+        "--row-dir",
+        type=Path,
+        help="Write full per-game rows to this directory",
+    )
 
     # time (delegates to measure_sim_times which parses its own args)
     sub.add_parser("time", help="Benchmark simulation throughput", add_help=False)
@@ -98,6 +108,15 @@ def main(argv: Sequence[str] | None = None) -> None:
     cfg = load_config(args.config, args.overrides)
 
     if args.command == "run":
+        if args.metrics:
+            cfg["collect_metrics"] = True
+        row_dir = args.row_dir
+        if row_dir is not None:
+            cfg["row_output_directory"] = row_dir
+        elif "row_output_directory" in cfg and isinstance(
+            cfg["row_output_directory"], str
+        ):
+            cfg["row_output_directory"] = Path(cfg["row_output_directory"])
         run_tournament(**cfg)
     elif args.command == "time":
         measure_sim_times()

--- a/tests/unit/simulation/test_runner_wrapper.py
+++ b/tests/unit/simulation/test_runner_wrapper.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pickle
+from collections import Counter
+from pathlib import Path
+
+import farkle.simulation.runner as runner
+
+
+def test_runner_passes_metric_flags(tmp_path, monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_run_tournament(**kwargs):  # noqa: ANN001 - signature mirrors target
+        calls.update(kwargs)
+        ckpt_path: Path = kwargs["checkpoint_path"]
+        ckpt_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"win_totals": Counter({"alpha": 3})}
+        ckpt_path.write_bytes(pickle.dumps(payload))
+
+    monkeypatch.setattr(runner.tournament_mod, "run_tournament", fake_run_tournament)
+
+    cfg = runner.AppConfig(
+        io=runner.IOConfig(results_dir=tmp_path / "out"),
+        sim=runner.SimConfig(
+            jobs=None,
+            seed=11,
+            n_games=4,
+            n_players=2,
+            collect_metrics=True,
+            row_dir=Path("rows"),
+        ),
+    )
+
+    total_games = runner.run_tournament(cfg)
+
+    assert calls["collect_metrics"] is True
+    assert calls["row_output_directory"] == tmp_path / "out" / "rows"
+    assert calls["checkpoint_path"] == tmp_path / "out" / "checkpoint.pkl"
+    expected_games = runner.TournamentConfig(n_players=2).games_per_shuffle
+    assert total_games == expected_games
+
+    csv_path = tmp_path / "out" / "win_counts.csv"
+    assert csv_path.exists()
+    assert "alpha" in csv_path.read_text()

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -15,7 +15,11 @@ def test_load_app_config_overlay(tmp_path: Path) -> None:
     overlay.write_text(
         yaml.safe_dump(
             {
-                "sim": {"n_players": 3},
+                "sim": {
+                    "n_players": 3,
+                    "collect_metrics": True,
+                    "row_dir": str(tmp_path / "rows"),
+                },
                 "analysis": {"run_trueskill": False},
                 "io": {"results_dir": str(tmp_path / "out")},
             }
@@ -23,6 +27,8 @@ def test_load_app_config_overlay(tmp_path: Path) -> None:
     )
     cfg = load_app_config(BASE_CFG, overlay)
     assert cfg.sim.n_players == 3
+    assert cfg.sim.collect_metrics is True
+    assert cfg.sim.row_dir == tmp_path / "rows"
     assert cfg.analysis.run_trueskill is False
     assert cfg.io.results_dir == tmp_path / "out"
     # Deep merge preserves unspecified keys
@@ -38,9 +44,13 @@ def test_apply_dot_overrides(tmp_path: Path) -> None:
         "analysis.trueskill_beta=3.5",
         "analysis.n_jobs=4",
         "analysis.log_level=DEBUG",
+        "sim.collect_metrics=true",
+        f"sim.row_dir={tmp_path / 'rows'}",
     ]
     apply_dot_overrides(cfg, pairs)
     assert cfg.sim.n_players == 7
+    assert cfg.sim.collect_metrics is True
+    assert cfg.sim.row_dir == tmp_path / "rows"
     assert cfg.analysis.run_trueskill is False
     assert cfg.io.results_dir == tmp_path / "results"
     assert cfg.analysis.trueskill_beta == 3.5


### PR DESCRIPTION
## Summary
- add `collect_metrics` and `row_dir` fields to the simulation config loader
- teach the runner wrapper to forward metrics and row options to the core tournament driver
- expose `--metrics` and `--row-dir` flags in the CLI and add unit coverage

## Testing
- `pytest tests/unit/test_app_config.py tests/unit/simulation/test_runner_wrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9cbeffeec832f84c163ae1ec8657b