### PR TITLE
Rename analysis aggregate module to combine

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ examples.
 Compute ratings for a directory of tournament results:
 
 ```bash
-farkle --config analysis/pipeline.yaml analyze metrics
+farkle --config analysis/pipeline.yaml analyze pipeline
 ```
 
 This scans `data/results_seed_0` for blocks and writes rating files and
-`tiers.json` to `data/results_seed_0/analysis` by default.
+`tiers.json` to `data/results_seed_0/analysis` by default. The pipeline includes
+`combine`, which merges curated per-seat Parquet shards into a single
+`all_ingested_rows.parquet` superset used by downstream analytics.

--- a/cli_args.md
+++ b/cli_args.md
@@ -57,9 +57,10 @@ compatible with `farkle.analysis.analysis_config.PipelineCfg`.
 Subcommands:
 - `ingest` – load raw CSV data into Parquet shards.
 - `curate` – post-process ingested data and update manifests.
+- `combine` – merge curated Parquet shards into a single superset file.
 - `metrics` – compute aggregate metrics (including TrueSkill ratings when
   enabled in the configuration).
-- `pipeline` – run `ingest`, `curate`, and `metrics` in sequence.
+- `pipeline` – run `ingest`, `curate`, `combine`, and `metrics` in sequence.
 
 Example usage:
 

--- a/configs/presets/full.yaml
+++ b/configs/presets/full.yaml
@@ -7,7 +7,7 @@ io:
 ingest:
   row_group_size: 262144
   n_jobs: 3
-aggregate:
+combine:
   max_players: 12
 metrics:
   seat_range: [1, 12]

--- a/src/farkle/analysis/analysis_config.py
+++ b/src/farkle/analysis/analysis_config.py
@@ -124,7 +124,7 @@ class PipelineCfg:
     def curated_parquet(self) -> Path:
         legacy = self.analysis_dir / "data" / self.curated_rows_name
         combined = self.data_dir / "all_n_players_combined" / "all_ingested_rows.parquet"
-        # Prefer aggregated superset if present; fallback to legacy path
+        # Prefer combined superset if present; fallback to legacy path
         return combined if combined.exists() or not legacy.exists() else legacy
       
     def to_json(self) -> str:
@@ -248,7 +248,7 @@ class Ingest(BaseModel):
     n_jobs: int = 1
 
 
-class Aggregate(BaseModel):
+class Combine(BaseModel):
     max_players: int = 12
 
 
@@ -282,7 +282,7 @@ class Config(BaseModel):
     experiment: Experiment
     io: IO
     ingest: Ingest = Ingest()
-    aggregate: Aggregate = Aggregate()
+    combine: Combine = Combine()
     metrics: Metrics = Metrics()
     trueskill: TrueSkillCfg = TrueSkillCfg()
     head2head: Head2Head = Head2Head()

--- a/src/farkle/analysis/checks.py
+++ b/src/farkle/analysis/checks.py
@@ -19,7 +19,7 @@ def check_pre_metrics(combined_parquet: Path, winner_col: str = "winner") -> Non
     Parameters
     ----------
     combined_parquet:
-        Path to the aggregated parquet produced by :mod:`aggregate`.
+        Path to the combined parquet produced by :mod:`combine`.
     winner_col:
         Name of the column holding the winner label.
     """
@@ -74,20 +74,20 @@ def check_pre_metrics(combined_parquet: Path, winner_col: str = "winner") -> Non
     log.info("✓ check_pre_metrics OK")
 
 
-def check_post_aggregate(
+def check_post_combine(
     curated_files: list[Path],
     combined_parquet: Path,
     max_players: int = 12,
 ) -> None:
     """Assert sum(rows per N) == combined rows; schema has P1..P12 templates."""
     if not combined_parquet.exists():
-        raise RuntimeError(f"check_post_aggregate: missing {combined_parquet}")
+        raise RuntimeError(f"check_post_combine: missing {combined_parquet}")
 
     try:
         combined_pf = pq.ParquetFile(combined_parquet)
     except Exception as e:  # noqa: BLE001
         raise RuntimeError(
-            f"check_post_aggregate: unable to read {combined_parquet}: {e}"
+            f"check_post_combine: unable to read {combined_parquet}: {e}"
         ) from e
     combined_rows = combined_pf.metadata.num_rows
 
@@ -96,16 +96,16 @@ def check_post_aggregate(
         try:
             total_rows += pq.ParquetFile(f).metadata.num_rows
         except Exception as e:  # noqa: BLE001
-            raise RuntimeError(f"check_post_aggregate: unable to read {f}: {e}") from e
+            raise RuntimeError(f"check_post_combine: unable to read {f}: {e}") from e
     if combined_rows != total_rows:
         raise RuntimeError(
-            "check_post_aggregate: row-count mismatch "
+            "check_post_combine: row-count mismatch "
             f"{combined_rows} != {total_rows}"
         )
 
     expected = expected_schema_for(max_players).names
     actual = pq.read_schema(combined_parquet).names
     if actual != expected:
-        raise RuntimeError("check_post_aggregate: output schema mismatch")
+        raise RuntimeError("check_post_combine: output schema mismatch")
 
-    log.info("✓ check_post_aggregate OK")
+    log.info("✓ check_post_combine OK")

--- a/src/farkle/analysis/metrics.py
+++ b/src/farkle/analysis/metrics.py
@@ -96,7 +96,7 @@ def run(cfg: AppConfig | PipelineCfg) -> None:
 
     if not data_file.exists():
         raise FileNotFoundError(
-            f"metrics: missing aggregated parquet {data_file} – run aggregate step first"
+            f"metrics: missing combined parquet {data_file} – run combine step first"
         )
 
     def _stamp(path: Path) -> dict[str, float | int]:
@@ -205,7 +205,7 @@ def run(cfg: AppConfig | PipelineCfg) -> None:
     # denom[seat] = sum of rows across all N where that seat exists (i.e., N >= seat)
     denom = {i: sum(_rows_for_n(n) for n in range(i, 13)) for i in range(1, 13)}
 
-    # wins per seat (from aggregate parquet)
+    # wins per seat (from combined parquet)
     ds_all = ds.dataset(data_file, format="parquet")
     seat_wins: dict[int, int] = {
         i: int(ds_all.count_rows(filter=(ds.field(winner_col) == f"P{i}")))

--- a/src/farkle/analysis/pipeline.py
+++ b/src/farkle/analysis/pipeline.py
@@ -10,7 +10,7 @@ import yaml
 from tqdm import tqdm
 
 from farkle import analysis
-from farkle.analysis import aggregate, curate, ingest, metrics
+from farkle.analysis import combine, curate, ingest, metrics
 from farkle.analysis.analysis_config import load_config
 from farkle.app_config import AppConfig
 
@@ -26,7 +26,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "--config", type=Path, default=Path("analysis_config.yaml"), help="Path to YAML config"
     )
     sub = parser.add_subparsers(dest="command", required=True)
-    for name in ("ingest", "curate", "aggregate", "metrics", "analytics", "all"):
+    for name in ("ingest", "curate", "combine", "metrics", "analytics", "all"):
         sub.add_parser(name)
 
     args = parser.parse_args(argv)
@@ -55,8 +55,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         ingest.run(app_cfg)
     elif args.command == "curate":
         curate.run(app_cfg)
-    elif args.command == "aggregate":
-        aggregate.run(app_cfg)
+    elif args.command == "combine":
+        combine.run(app_cfg)
     elif args.command == "metrics":
         metrics.run(app_cfg)
     elif args.command == "analytics":
@@ -65,7 +65,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         steps: list[tuple[str, Callable[[AppConfig], None]]] = [
             ("ingest", ingest.run),
             ("curate", curate.run),
-            ("aggregate", aggregate.run),
+            ("combine", combine.run),
             ("metrics", metrics.run),
             ("analytics", analysis.run_all),
         ]

--- a/src/farkle/cli/main.py
+++ b/src/farkle/cli/main.py
@@ -7,7 +7,7 @@ from typing import Any, Sequence
 
 import yaml
 
-from farkle.analysis import curate, ingest, metrics
+from farkle.analysis import combine, curate, ingest, metrics
 from farkle.simulation.run_tournament import run_tournament
 from farkle.simulation.time_farkle import measure_sim_times
 from farkle.simulation.watch_game import watch_game
@@ -89,8 +89,9 @@ def build_parser() -> argparse.ArgumentParser:
     analyze_sub = analyze_parser.add_subparsers(dest="an_cmd", required=True)
     analyze_sub.add_parser("ingest", help="Ingest raw CSV data")
     analyze_sub.add_parser("curate", help="Curate ingested data")
+    analyze_sub.add_parser("combine", help="Combine curated data into a superset parquet")
     analyze_sub.add_parser("metrics", help="Compute metrics")
-    analyze_sub.add_parser("pipeline", help="Run ingest→curate→metrics pipeline")
+    analyze_sub.add_parser("pipeline", help="Run ingest→curate→combine→metrics pipeline")
 
     return parser
 
@@ -130,11 +131,14 @@ def main(argv: Sequence[str] | None = None) -> None:
             ingest.run(pipeline_cfg)
         elif args.an_cmd == "curate":
             curate.run(pipeline_cfg)
+        elif args.an_cmd == "combine":
+            combine.run(pipeline_cfg)
         elif args.an_cmd == "metrics":
             metrics.run(pipeline_cfg)
         elif args.an_cmd == "pipeline":
             ingest.run(pipeline_cfg)
             curate.run(pipeline_cfg)
+            combine.run(pipeline_cfg)
             metrics.run(pipeline_cfg)
     else:  # pragma: no cover - argparse enforces valid choices
         parser.error(f"Unknown command {args.command}")

--- a/tests/unit/analysis/test_analysis_pipeline.py
+++ b/tests/unit/analysis/test_analysis_pipeline.py
@@ -77,14 +77,14 @@ def test_pipeline_ingest_only(tmp_path: Path) -> None:
     assert not combined.exists()
 
 
-def test_pipeline_aggregate_only(tmp_path: Path) -> None:
+def test_pipeline_combine_only(tmp_path: Path) -> None:
     _write_fixture(tmp_path)
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
         pipeline.main(["ingest", "--root", str(tmp_path)])
         pipeline.main(["curate", "--root", str(tmp_path)])
-        pipeline.main(["aggregate", "--root", str(tmp_path)])
+        pipeline.main(["combine", "--root", str(tmp_path)])
     finally:
         os.chdir(cwd)
 
@@ -112,7 +112,7 @@ def test_pipeline_missing_dependency(tmp_path: Path, monkeypatch: pytest.MonkeyP
     [
         ("ingest", "farkle.analysis.ingest.run"),
         ("curate", "farkle.analysis.curate.run"),
-        ("aggregate", "farkle.analysis.aggregate.run"),
+        ("combine", "farkle.analysis.combine.run"),
         ("metrics", "farkle.analysis.metrics.run"),
         ("analytics", "farkle.analysis.run_all"),
     ],
@@ -165,10 +165,10 @@ def test_pipeline_all_step_failure_prints_and_raises(
 
     monkeypatch.setattr("farkle.analysis.ingest.run", _ok)
     monkeypatch.setattr("farkle.analysis.curate.run", _ok)
-    monkeypatch.setattr("farkle.analysis.aggregate.run", _boom)
+    monkeypatch.setattr("farkle.analysis.combine.run", _boom)
 
     with pytest.raises(RuntimeError):
         pipeline.main(["all", "--root", str(tmp_path)])
 
     err = capsys.readouterr().err
-    assert "aggregate step failed: boom" in err
+    assert "combine step failed: boom" in err

--- a/tests/unit/analysis/test_combine.py
+++ b/tests/unit/analysis/test_combine.py
@@ -2,14 +2,14 @@ from pathlib import Path
 import pyarrow as pa
 import pyarrow.parquet as pq
 from farkle.analysis.analysis_config import PipelineCfg, expected_schema_for
-from farkle.analysis import aggregate
+from farkle.analysis import combine
 
 def _write_curated(path: Path, schema: pa.Schema, rows: list[dict]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tbl = pa.Table.from_pylist(rows, schema=schema)
     pq.write_table(tbl, path)
 
-def test_aggregate_pads_and_counts(tmp_path: Path) -> None:
+def test_combine_pads_and_counts(tmp_path: Path) -> None:
     cfg = PipelineCfg(results_dir=tmp_path)
     # create per-N curated files
     p1 = cfg.ingested_rows_curated(1)
@@ -22,8 +22,8 @@ def test_aggregate_pads_and_counts(tmp_path: Path) -> None:
     _write_curated(p2, schema2, [
         {"winner": "P1", "n_rounds": 1, "winning_score": 200, "P1_strategy": "A", "P2_strategy": "B", "P1_rank": 1, "P2_rank": 2},
     ])
-    # run aggregate
-    aggregate.run(cfg)
+    # run combine
+    combine.run(cfg)
     out = cfg.data_dir / "all_n_players_combined" / "all_ingested_rows.parquet"
     pf = pq.ParquetFile(out)
     assert pf.metadata.num_rows == 2


### PR DESCRIPTION
## Summary
- rename the analysis step that merges parquet shards from `aggregate` to `combine`, including the new module and pipeline integrations
- adjust downstream references (TrueSkill, metrics, checks) plus configuration defaults, CLI support, docs, and tests to reflect the combined dataset terminology

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68c9d91e92cc832f9a3a88376b261777