### PR TITLE
Remove legacy analysis CLIs in favor of direct functions

### DIFF
--- a/src/farkle/analysis/run_bonferroni_head2head.py
+++ b/src/farkle/analysis/run_bonferroni_head2head.py
@@ -3,10 +3,8 @@
 
 from __future__ import annotations
 
-import argparse
 import json
 from pathlib import Path
-from typing import List
 
 import pandas as pd
 from scipy.stats import binomtest
@@ -79,21 +77,3 @@ def run_bonferroni_head2head(*, seed: int = 0, root: Path = DEFAULT_ROOT, n_jobs
     tmp_path = pairwise_parquet.with_suffix(".tmp")
     out.to_csv(tmp_path, index=False)
     tmp_path.replace(pairwise_parquet)
-
-
-def main(argv: List[str] | None = None) -> None:
-    """Command line interface for :func:`run_bonferroni_head2head`.
-
-    Usage
-        python -m farkle.run_bonferroni_head2head [--seed N] [--root R] [--jobs J]
-    """
-    parser = argparse.ArgumentParser(description="Head-to-head Bonferroni analysis")
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
-    parser.add_argument("--jobs", type=int, default=1, help="worker processes")
-    args = parser.parse_args(argv)
-    run_bonferroni_head2head(seed=args.seed, root=args.root, n_jobs=args.jobs)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/farkle/analysis/run_hgb.py
+++ b/src/farkle/analysis/run_hgb.py
@@ -8,14 +8,12 @@ permutation feature importances and partial dependence plots.
 
 from __future__ import annotations
 
-import argparse
 import json
 import logging
 import pickle
 import re
 import warnings
 from pathlib import Path
-from typing import List
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -211,38 +209,3 @@ def run_hgb(
         )
     for col in cols[:MAX_PD_PLOTS]:
         plot_partial_dependence(model, features, col, FIG_DIR)
-
-
-def main(argv: List[str] | None = None) -> None:
-    """Entry point for ``python -m farkle.run_hgb``.
-
-    Parameters
-    ----------
-    argv : List[str] | None, optional
-        Command line arguments, or ``None`` to use ``sys.argv``. Only a single
-        ``--seed`` option is accepted.
-    """
-
-    parser = argparse.ArgumentParser(
-        description=(
-            "Train a HistGradientBoostingRegressor using data/metrics.parquet and "
-            "data/ratings_pooled.parquet. Run from the project root. Writes "
-            "hgb_importance.json to --output and partial dependence plots to "
-            "notebooks/figs/."
-        )
-    )
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument(
-        "-o",
-        "--output",
-        type=Path,
-        default=None,
-        help="Path to write hgb_importance.json",
-    )
-    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
-    args = parser.parse_args(argv or [])
-    run_hgb(seed=args.seed, output_path=args.output, root=args.root)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -29,7 +29,7 @@ __all__ = [
 def main(argv: object | None = None) -> int:
     """Thin wrapper importing :func:`farkle.pipeline.main` lazily."""
 
-    from farkle.pipeline import main as _main
+    from farkle.analysis.pipeline import main as _main
 
     return _main(argv) # pyright: ignore[reportArgumentType]
 
@@ -104,9 +104,9 @@ def analyze_trueskill(exp_dir: Path) -> None:
         return
 
     analysis_dir.mkdir(parents=True, exist_ok=True)
-    from farkle import run_trueskill as _rt
+    from farkle.analysis import run_trueskill as _rt
 
-    _rt.main(["--dataroot", str(exp_dir), "--root", str(analysis_dir)])
+    _rt.run_trueskill(root=analysis_dir, dataroot=exp_dir)
     write_done(done, inputs, [out], "farkle.analytics.trueskill")
     print("trueskill")
 
@@ -125,7 +125,7 @@ def analyze_h2h(exp_dir: Path) -> None:
         return
 
     analysis_dir.mkdir(parents=True, exist_ok=True)
-    from farkle import run_bonferroni_head2head as _h2h
+    from farkle.analysis import run_bonferroni_head2head as _h2h
 
     _h2h.run_bonferroni_head2head(root=exp_dir, n_jobs=1)
     write_done(done, inputs, [out], "farkle.analytics.head2head")
@@ -147,7 +147,7 @@ def analyze_hgb(exp_dir: Path) -> None:
         return
 
     analysis_dir.mkdir(parents=True, exist_ok=True)
-    from farkle import run_hgb as _hgb
+    from farkle.analysis import run_hgb as _hgb
 
     _hgb.run_hgb(root=analysis_dir, output_path=out)
     write_done(done, inputs, [out], "farkle.analytics.hgb")

--- a/tests/unit/analysis/test_pipeline_analytics.py
+++ b/tests/unit/analysis/test_pipeline_analytics.py
@@ -25,9 +25,9 @@ def test_analyze_all_skips_when_up_to_date(tmp_path, monkeypatch):
     analysis = exp / "analysis"
 
     # stub tools to create outputs
-    def fake_ts(args):
+    def fake_ts(*, root=None, dataroot=None, **_: object):  # noqa: ANN001, ARG001
         (analysis / "tiers.json").write_text("{}")
-    monkeypatch.setattr("farkle.analysis.run_trueskill.main", fake_ts)
+    monkeypatch.setattr("farkle.analysis.run_trueskill.run_trueskill", fake_ts)
 
     def fake_h2h(*, root, n_jobs=1):  # noqa: ARG001
         (analysis / "bonferroni_pairwise.csv").write_text("a,b")

--- a/tests/unit/analysis/test_run_bonferroni_head2head.py
+++ b/tests/unit/analysis/test_run_bonferroni_head2head.py
@@ -109,17 +109,3 @@ def test_run_bonferroni_head2head_empty_file(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     with pytest.raises(RuntimeError, match="No tiers found"):
         rb.run_bonferroni_head2head(root=data_dir)
-
-
-def test_main_delegates_to_runner(monkeypatch):
-    captured = {}
-
-    def fake_run(seed: int = 0, root=None, n_jobs: int = 1) -> None:  # noqa: ANN001
-        _ = root
-        captured["seed"] = seed
-        captured["n_jobs"] = n_jobs
-
-    monkeypatch.setattr(rb, "run_bonferroni_head2head", fake_run)
-    rb.main(["--seed", "42", "--root", "d", "--jobs", "5"])
-    assert captured["seed"] == 42
-    assert captured["n_jobs"] == 5

--- a/tests/unit/analysis/test_run_full_field.py
+++ b/tests/unit/analysis/test_run_full_field.py
@@ -24,7 +24,7 @@ def test_concat_row_shards(tmp_path: rf.Path):
     assert list(pd.read_parquet(merged)["v"]) == [1, 2]
 
 
-def test_main_invokes_run_tournament(monkeypatch: MonkeyPatch, tmp_path: rf.Path):
+def test_run_full_field_invokes_run_tournament(monkeypatch: MonkeyPatch, tmp_path: rf.Path):
     calls = []
 
     def fake_run_tournament(**kwargs):
@@ -34,7 +34,7 @@ def test_main_invokes_run_tournament(monkeypatch: MonkeyPatch, tmp_path: rf.Path
     monkeypatch.setattr(rf.mp, "set_start_method", lambda *a, **k: None)  # noqa: ARG005
     monkeypatch.chdir(tmp_path)
 
-    rf.main()
+    rf.run_full_field()
 
     players = [2, 3, 4, 5, 6, 8, 10, 12]
     seen = sorted(int(p[0].parent.name.split("_")[0]) for p in calls)
@@ -43,7 +43,7 @@ def test_main_invokes_run_tournament(monkeypatch: MonkeyPatch, tmp_path: rf.Path
     assert all(isinstance(nshuf, int) for _, nshuf in calls)
 
 
-def test_main_skips_complete_and_resets_partial(
+def test_run_full_field_skips_complete_and_resets_partial(
     monkeypatch: MonkeyPatch, tmp_path: rf.Path
 ) -> None:
     calls = []
@@ -73,7 +73,7 @@ def test_main_skips_complete_and_resets_partial(
     row_dir.mkdir(parents=True)
     (row_dir / "a.parquet").write_text("partial")
 
-    rf.main()
+    rf.run_full_field()
 
     # 2-player run skipped, 3-player run executed with reset
     players_called = calls

--- a/tests/unit/analysis/test_run_hgb_functionality.py
+++ b/tests/unit/analysis/test_run_hgb_functionality.py
@@ -153,7 +153,7 @@ def test_partial_dependence_warning_and_limit(tmp_path, monkeypatch, caplog):
     assert plotted == [f"feat{i}" for i in range(run_hgb.MAX_PD_PLOTS)]
 
 
-def test_main_default_output(tmp_path, monkeypatch):
+def test_run_hgb_default_output(tmp_path, monkeypatch):
     data_dir = _setup_data(tmp_path)
 
     class DummyModel:
@@ -178,5 +178,5 @@ def test_main_default_output(tmp_path, monkeypatch):
         lambda model, X, column, out_dir: Path(out_dir) / f"pd_{column}.png",  # noqa: ARG005
     )
 
-    run_hgb.main(["--root", str(data_dir)])
+    run_hgb.run_hgb(root=data_dir)
     assert (data_dir / "hgb_importance.json").exists()

--- a/tests/unit/analysis/test_run_trueskill_pooling.py
+++ b/tests/unit/analysis/test_run_trueskill_pooling.py
@@ -53,7 +53,7 @@ def test_pooled_ratings_are_weighted_mean(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        run_trueskill.main(["--root", str(data_root)])
+        run_trueskill.run_trueskill(root=data_root)
     finally:
         os.chdir(cwd)
 


### PR DESCRIPTION
## Summary
- drop the argparse-based `main` shims from the analysis helpers and update `run_full_field` to expose a callable API
- point the compatibility `pipeline` module at the new config-aware entry points
- refresh unit tests to exercise the new function-based interfaces

## Testing
- `pytest` *(fails: missing `simulate_many_games_stream` export in farkle.utils.parallel during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e12abb88832fb88030104a1d8a96