### PR TITLE
Ensure atomic file writes and consistent loggers

### DIFF
--- a/src/farkle/analysis/combine.py
+++ b/src/farkle/analysis/combine.py
@@ -12,7 +12,7 @@ from farkle.analysis.checks import check_post_combine
 from farkle.app_config import AppConfig
 from farkle.utils.streaming_loop import run_streaming_shard
 
-log = logging.getLogger("combine")
+log = logging.getLogger(__name__)
 
 def _pad_to_schema(tbl: pa.Table, target: pa.Schema) -> pa.Table:
     cols = []

--- a/src/farkle/analysis/hgb_feat.py
+++ b/src/farkle/analysis/hgb_feat.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from farkle.analysis import run_hgb as _hgb
 from farkle.analysis.analysis_config import PipelineCfg
 from farkle.app_config import AppConfig
+from farkle.utils.writer import atomic_path
 
 log = logging.getLogger(__name__)
 
@@ -24,6 +26,8 @@ def run(cfg: AppConfig | PipelineCfg) -> None:
     ratings_src = cfg.results_dir / "ratings_pooled.pkl"
     ratings_dst = cfg.analysis_dir / "ratings_pooled.pkl"
     if ratings_src.exists() and not ratings_dst.exists():
-        ratings_dst.write_bytes(ratings_src.read_bytes())
+        ratings_dst.parent.mkdir(parents=True, exist_ok=True)
+        with atomic_path(str(ratings_dst)) as tmp_path:
+            Path(tmp_path).write_bytes(ratings_src.read_bytes())
 
     _hgb.run_hgb(root=cfg.analysis_dir, output_path=out)

--- a/src/farkle/analysis/run_bonferroni_head2head.py
+++ b/src/farkle/analysis/run_bonferroni_head2head.py
@@ -12,6 +12,7 @@ from scipy.stats import binomtest
 from farkle.simulation.simulation import simulate_many_games_from_seeds
 from farkle.simulation.strategies import parse_strategy
 from farkle.utils.stats import bonferroni_pairs, games_for_power
+from farkle.utils.writer import atomic_path
 
 DEFAULT_ROOT = Path("results_seed_0")
 
@@ -72,8 +73,7 @@ def run_bonferroni_head2head(*, seed: int = 0, root: Path = DEFAULT_ROOT, n_jobs
         records.append({"a": a, "b": b, "wins_a": wa, "wins_b": wb, "pvalue": pval})
 
     out = pd.DataFrame(records)
-    pairwise_parquet.parent.mkdir(exist_ok=True)
+    pairwise_parquet.parent.mkdir(parents=True, exist_ok=True)
 
-    tmp_path = pairwise_parquet.with_suffix(".tmp")
-    out.to_csv(tmp_path, index=False)
-    tmp_path.replace(pairwise_parquet)
+    with atomic_path(str(pairwise_parquet)) as tmp_path:
+        out.to_csv(tmp_path, index=False)

--- a/src/farkle/analysis/run_full_field.py
+++ b/src/farkle/analysis/run_full_field.py
@@ -18,6 +18,7 @@ import pandas as pd
 from scipy.stats import norm
 
 from farkle.game.scoring_lookup import build_score_lookup_table
+from farkle.utils.writer import atomic_path
 
 SCORE_TABLE = build_score_lookup_table()
 
@@ -39,7 +40,9 @@ def _concat_row_shards(out_dir: Path, n_players: int) -> None:
     if not files:
         return
     df = pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
-    df.to_parquet(out_dir / f"{n_players}p_rows.parquet")
+    out_path = out_dir / f"{n_players}p_rows.parquet"
+    with atomic_path(str(out_path)) as tmp_path:
+        df.to_parquet(tmp_path)
     shutil.rmtree(row_dir, ignore_errors=True)
     del df  # free memory before returning
 

--- a/src/farkle/simulation/run_tournament.py
+++ b/src/farkle/simulation/run_tournament.py
@@ -30,6 +30,7 @@ from farkle.simulation.strategies import ThresholdStrategy
 from farkle.utils import parallel
 from farkle.utils import random as urandom
 from farkle.utils.streaming_loop import run_streaming_shard
+from farkle.utils.writer import atomic_path
 
 # from farkle.utils.logging import setup_info_logging, setup_warning_logging
 
@@ -310,7 +311,9 @@ def _save_checkpoint(
     if sums is not None and sq_sums is not None:
         payload["metric_sums"] = sums
         payload["metric_square_sums"] = sq_sums
-    path.write_bytes(pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with atomic_path(str(path)) as tmp_path:
+        Path(tmp_path).write_bytes(pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL))
 
 
 # ---------------------------------------------------------------------------

--- a/src/farkle/simulation/watch_game.py
+++ b/src/farkle/simulation/watch_game.py
@@ -29,7 +29,7 @@ from farkle.utils.random import make_rng, spawn_seeds
 
 # ── 1.  Plain-text logger ----------------------------------------------------
 logging.basicConfig(level=logging.INFO, format="%(message)s", handlers=[logging.StreamHandler()])
-log = logging.getLogger("watch")
+log = logging.getLogger(__name__)
 
 
 # ── 2.  Tiny helpers ---------------------------------------------------------

--- a/src/farkle/utils/sinks.py
+++ b/src/farkle/utils/sinks.py
@@ -2,9 +2,13 @@
 from __future__ import annotations
 
 import csv
+import sys
 from collections import Counter
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
+
+from .writer import atomic_path
 
 # ------------------------
 # CSV sink (stream-friendly)
@@ -21,31 +25,44 @@ class CsvSink:
         self.mode = mode
         self._writer: csv.DictWriter | None = None
         self._file = None  # type: ignore[assignment]
+        self._atomic_cm = None
 
     # --- context manager hooks ---
     def __enter__(self):
         return self.open()
 
     def __exit__(self, exc_type, exc, tb):
-        self.close()
+        self.close(exc_type, exc, tb)
         # return False to propagate exceptions (typical for I/O contexts)
         return False
 
     # --- lifecycle ---
     def open(self):
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._file = open(self.path, self.mode, newline="", encoding="utf-8")  #noqa:SIM115
+        ctx = nullcontext(str(self.path))
+        if "w" in self.mode and "a" not in self.mode:
+            ctx = atomic_path(str(self.path))
+        tmp_path = ctx.__enter__()
+        try:
+            self._file = open(tmp_path, self.mode, newline="", encoding="utf-8")  #noqa:SIM115
+        except Exception:
+            ctx.__exit__(*sys.exc_info())
+            raise
+        self._atomic_cm = ctx
         self._writer = csv.DictWriter(self._file, fieldnames=self.header)
         if "w" in self.mode:
             self._writer.writeheader()
         return self  # allow `with CsvSink(...) as sink:`
 
-    def close(self):  # pragma: no cover - trivial
+    def close(self, exc_type=None, exc=None, tb=None):  # pragma: no cover - trivial
         if self._file is not None:
             self._file.flush()
             self._file.close()
             self._file = None
             self._writer = None
+        if self._atomic_cm is not None:
+            self._atomic_cm.__exit__(exc_type, exc, tb)
+            self._atomic_cm = None
 
     # --- writes ---
     def write_row(self, row: Mapping[str, object]) -> None:
@@ -64,10 +81,11 @@ class CsvSink:
 def write_counter_csv(counter: Counter[str], path: Path) -> None:
     """Write a Counter[str] to CSV as columns ``strategy,wins``."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", newline="", encoding="utf-8") as fh:
-        w = csv.writer(fh)
-        w.writerow(["strategy", "wins"])
-        for key, cnt in counter.items():
-            w.writerow([key, cnt])
+    with atomic_path(str(path)) as tmp_path:
+        with Path(tmp_path).open("w", newline="", encoding="utf-8") as fh:
+            w = csv.writer(fh)
+            w.writerow(["strategy", "wins"])
+            for key, cnt in counter.items():
+                w.writerow([key, cnt])
 
 __all__ = ["CsvSink", "write_counter_csv"]

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -14,6 +14,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+from farkle.utils.writer import atomic_path
 __all__ = [
     "main",
     "analyze_all",
@@ -68,7 +69,9 @@ def write_done(
         "version": 1,
         "created_at": datetime.utcnow().isoformat(),
     }
-    done_path.write_text(json.dumps(stamp, indent=2, sort_keys=True))
+    done_path.parent.mkdir(parents=True, exist_ok=True)
+    with atomic_path(str(done_path)) as tmp_path:
+        Path(tmp_path).write_text(json.dumps(stamp, indent=2, sort_keys=True))
 
 
 def is_up_to_date(done_path: Path, inputs: list[Path], outputs: list[Path]) -> bool:


### PR DESCRIPTION
## Summary
- wrap analytics and pipeline writes with `atomic_path` to guarantee atomic renames and manifest consistency
- update CSV/Parquet helpers and tournament checkpoints to rely on atomic contexts instead of manual temp files
- standardize module loggers to use `logging.getLogger(__name__)`

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68c9eb9ab448832fb9cd334da282803a