### PR TITLE
Refactor logging across modules and add log coverage tests

### DIFF
--- a/src/farkle/analysis/__init__.py
+++ b/src/farkle/analysis/__init__.py
@@ -10,7 +10,7 @@ from farkle.analysis import trueskill as _ts
 from farkle.analysis.analysis_config import PipelineCfg
 from farkle.app_config import AppConfig
 
-log = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def _pipeline_cfg(cfg: AppConfig | PipelineCfg) -> PipelineCfg:
@@ -20,19 +20,28 @@ def _pipeline_cfg(cfg: AppConfig | PipelineCfg) -> PipelineCfg:
 def run_all(cfg: AppConfig | PipelineCfg) -> None:
     """Run every analytics pass in sequence."""
     cfg = _pipeline_cfg(cfg)
-    log.info("Analytics: starting all modules")
+    LOGGER.info("Analytics: starting all modules", extra={"stage": "analysis"})
     if cfg.run_trueskill:
         _ts.run(cfg)
     else:
-        log.info("Analytics: skipping trueskill (run_trueskill=False)")
+        LOGGER.info(
+            "Analytics: skipping trueskill",
+            extra={"stage": "analysis", "reason": "run_trueskill=False"},
+        )
 
     if cfg.run_head2head:
         _h2h.run(cfg)
     else:
-        log.info("Analytics: skipping head-to-head (run_head2head=False)")
+        LOGGER.info(
+            "Analytics: skipping head-to-head",
+            extra={"stage": "analysis", "reason": "run_head2head=False"},
+        )
 
     if cfg.run_hgb:
         _hgb.run(cfg)
     else:
-        log.info("Analytics: skipping hist gradient boosting (run_hgb=False)")
-    log.info("Analytics: all modules finished")
+        LOGGER.info(
+            "Analytics: skipping hist gradient boosting",
+            extra={"stage": "analysis", "reason": "run_hgb=False"},
+        )
+    LOGGER.info("Analytics: all modules finished", extra={"stage": "analysis"})

--- a/src/farkle/analysis/checks.py
+++ b/src/farkle/analysis/checks.py
@@ -10,7 +10,7 @@ import pyarrow.parquet as pq
 
 from .analysis_config import expected_schema_for
 
-log = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def check_pre_metrics(combined_parquet: Path, winner_col: str = "winner") -> None:
@@ -71,7 +71,10 @@ def check_pre_metrics(combined_parquet: Path, winner_col: str = "winner") -> Non
             f"{combined_rows} != {manifest_rows}"
         )
 
-    log.info("✓ check_pre_metrics OK")
+    LOGGER.info(
+        "check_pre_metrics passed",
+        extra={"stage": "checks", "path": str(combined_parquet)},
+    )
 
 
 def check_post_combine(
@@ -108,4 +111,7 @@ def check_post_combine(
     if actual != expected:
         raise RuntimeError("check_post_combine: output schema mismatch")
 
-    log.info("✓ check_post_combine OK")
+    LOGGER.info(
+        "check_post_combine passed",
+        extra={"stage": "checks", "path": str(combined_parquet)},
+    )

--- a/src/farkle/analysis/head2head.py
+++ b/src/farkle/analysis/head2head.py
@@ -6,7 +6,7 @@ from farkle.analysis import run_bonferroni_head2head as _h2h
 from farkle.analysis.analysis_config import PipelineCfg
 from farkle.app_config import AppConfig
 
-log = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def _pipeline_cfg(cfg: AppConfig | PipelineCfg) -> PipelineCfg:
@@ -17,14 +17,27 @@ def run(cfg: AppConfig | PipelineCfg) -> None:
     cfg = _pipeline_cfg(cfg)
     out = cfg.analysis_dir / "bonferroni_pairwise.csv"
     if out.exists() and out.stat().st_mtime >= cfg.curated_parquet.stat().st_mtime:
-        log.info("Head-to-Head: results up-to-date - skipped")
+        LOGGER.info(
+            "Head-to-head results up-to-date",
+            extra={"stage": "head2head", "path": str(out)},
+        )
         return
 
-    log.info("Head-to-Head: running in-process")
+    LOGGER.info(
+        "Head-to-head analysis running",
+        extra={
+            "stage": "head2head",
+            "results_dir": str(cfg.results_dir),
+            "n_jobs": cfg.n_jobs,
+        },
+    )
     try:
         _h2h.run_bonferroni_head2head(root=cfg.results_dir, n_jobs=cfg.n_jobs)
     except Exception as e:  # noqa: BLE001
         # Strategy strings in small test fixtures may not be parseable by the
         # legacy head-to-head script. Rather than abort the entire analytics
         # pass, log and continue.
-        log.warning("Head-to-Head: skipped (%s)", e)
+        LOGGER.warning(
+            "Head-to-head skipped",
+            extra={"stage": "head2head", "error": str(e)},
+        )

--- a/src/farkle/analysis/pipeline.py
+++ b/src/farkle/analysis/pipeline.py
@@ -15,6 +15,8 @@ from farkle.analysis.analysis_config import load_config
 from farkle.app_config import AppConfig
 from farkle.utils.writer import atomic_path
 
+LOGGER = logging.getLogger(__name__)
+
 if TYPE_CHECKING:  # for type checkers without creating runtime deps
     from farkle.analysis.analysis_config import PipelineCfg  # noqa: F401
 
@@ -32,6 +34,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
+    LOGGER.info(
+        "Analysis pipeline start",
+        extra={"stage": "pipeline", "command": args.command, "config": str(args.config)},
+    )
     cfg, cfg_sha = load_config(Path(args.config))
     app_cfg = AppConfig(analysis=cfg.to_pipeline_cfg())
 
@@ -52,17 +58,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     with atomic_path(str(manifest_path)) as tmp_path:
         Path(tmp_path).write_text(json.dumps(manifest, indent=2))
 
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
-
     if args.command == "ingest":
+        LOGGER.info("Pipeline step: ingest", extra={"stage": "pipeline"})
         ingest.run(app_cfg)
     elif args.command == "curate":
+        LOGGER.info("Pipeline step: curate", extra={"stage": "pipeline"})
         curate.run(app_cfg)
     elif args.command == "combine":
+        LOGGER.info("Pipeline step: combine", extra={"stage": "pipeline"})
         combine.run(app_cfg)
     elif args.command == "metrics":
+        LOGGER.info("Pipeline step: metrics", extra={"stage": "pipeline"})
         metrics.run(app_cfg)
     elif args.command == "analytics":
+        LOGGER.info("Pipeline step: analytics", extra={"stage": "pipeline"})
         analysis.run_all(app_cfg)
     elif args.command == "all":
         steps: list[tuple[str, Callable[[AppConfig], None]]] = [
@@ -73,9 +82,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             ("analytics", analysis.run_all),
         ]
         for _name, fn in tqdm(steps, desc="pipeline"):
+            LOGGER.info(
+                "Pipeline step",
+                extra={"stage": "pipeline", "step": _name},
+            )
             fn(app_cfg)
     else:  # pragma: no cover - argparse enforces valid choices
         parser.error(f"Unknown command {args.command}")
+    LOGGER.info("Analysis pipeline complete", extra={"stage": "pipeline"})
     return 0
 
 

--- a/src/farkle/analysis/trueskill.py
+++ b/src/farkle/analysis/trueskill.py
@@ -6,7 +6,7 @@ from farkle.analysis import run_trueskill
 from farkle.analysis.analysis_config import PipelineCfg
 from farkle.app_config import AppConfig
 
-log = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def _pipeline_cfg(cfg: AppConfig | PipelineCfg) -> PipelineCfg:
@@ -18,8 +18,18 @@ def run(cfg: AppConfig | PipelineCfg) -> None:
     cfg = _pipeline_cfg(cfg)
     out = cfg.analysis_dir / "tiers.json"
     if out.exists() and out.stat().st_mtime >= cfg.curated_parquet.stat().st_mtime:
-        log.info("TrueSkill: results up-to-date - skipped")
+        LOGGER.info(
+            "TrueSkill results up-to-date",
+            extra={"stage": "trueskill", "path": str(out)},
+        )
         return
 
-    log.info("TrueSkill: running in-process")
+    LOGGER.info(
+        "TrueSkill analysis running",
+        extra={"stage": "trueskill", "analysis_dir": str(cfg.analysis_dir)},
+    )
     run_trueskill.run_trueskill(root=cfg.analysis_dir)
+    LOGGER.info(
+        "TrueSkill analysis complete",
+        extra={"stage": "trueskill", "path": str(out)},
+    )

--- a/tests/unit/analysis/test_ingest.py
+++ b/tests/unit/analysis/test_ingest.py
@@ -109,3 +109,18 @@ def test_run_schema_mismatch_logs_and_closes(tmp_path, caplog, monkeypatch):
 
     assert any("Schema mismatch" in rec.message for rec in caplog.records)
     assert len(calls) == 1
+
+
+def test_run_emits_logging(tmp_path, caplog):
+    cfg = PipelineCfg(results_dir=tmp_path, analysis_subdir="analysis")
+    block = cfg.results_dir / "2_players"
+    block.mkdir(parents=True)
+    df = pd.DataFrame({"winner": ["P1"], "P1_strategy": ["A"], "n_rounds": [1], "winning_score": [100]})
+    df.to_parquet(block / "2p_rows.parquet", index=False)
+
+    caplog.set_level(logging.INFO, logger="farkle.analysis.ingest")
+    run(cfg)
+
+    messages = [rec.message for rec in caplog.records]
+    assert any("Ingest started" in msg for msg in messages)
+    assert any("Ingest block complete" in msg for msg in messages)

--- a/tests/unit/analysis/test_run_full_field.py
+++ b/tests/unit/analysis/test_run_full_field.py
@@ -92,10 +92,10 @@ def test_combo_complete_force_clean(tmp_path: rf.Path, caplog: pytest.LogCapture
     with caplog.at_level("WARNING"):
         rf._combo_complete(out_dir, n)
     assert row_dir.exists()
-    assert "--force-clean" in caplog.text
+    assert any("Row directory exists" in rec.message for rec in caplog.records)
 
     caplog.clear()
     with caplog.at_level("WARNING"):
         rf._combo_complete(out_dir, n, force_clean=True)
     assert not row_dir.exists()
-    assert "Deleting existing row directory" in caplog.text
+    assert any("Deleting existing row directory" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- replace print statements with structured logging across analysis and simulation modules
- add module-level loggers, INFO/DEBUG lifecycle telemetry, and CLI logging refinements
- extend tests to capture ingest and tournament logging via caplog

## Testing
- pytest *(fails: missing simulate_many_games_stream import in legacy tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c9efb3f6f0832f996f6b27d76a2bf4