### PR TITLE
Update analysis-light pipeline regression tests

### DIFF
--- a/tests/unit/analysis_light/test_pipeline_stabilizers.py
+++ b/tests/unit/analysis_light/test_pipeline_stabilizers.py
@@ -1,13 +1,15 @@
-import logging
-
 import json
 import logging
 
 import pandas as pd
 import pyarrow.parquet as pq
+import pytest
 
 from farkle.analysis import combine, curate, ingest, metrics
 from farkle.analysis.analysis_config import PipelineCfg
+
+
+STRATEGY_MAP = {"P1": "Aggro", "P2": "Balanced", "P3": "Cautious"}
 
 
 def test_ingest_golden_dataset(tmp_path, caplog, golden_dataset):
@@ -20,8 +22,27 @@ def test_ingest_golden_dataset(tmp_path, caplog, golden_dataset):
     raw_file = cfg.ingested_rows_raw(3)
     assert raw_file.exists()
     table = pq.read_table(raw_file)
+    columns = set(table.column_names)
+    assert {"winner_seat", "winner_strategy", "seat_ranks"}.issubset(columns)
     assert table.num_rows == len(golden_dataset.dataframe)
     df = table.to_pandas()
+    observed_strategies = (
+        df[["winner_seat", "winner_strategy"]]
+        .drop_duplicates()
+        .set_index("winner_seat")
+        ["winner_strategy"]
+        .to_dict()
+    )
+    expected_strategies = (
+        golden_dataset.dataframe[["winner"]]
+        .drop_duplicates()
+        .assign(winner_strategy=lambda frame: frame["winner"].map(STRATEGY_MAP))
+        .set_index("winner")
+        ["winner_strategy"]
+        .to_dict()
+    )
+    assert observed_strategies == expected_strategies
+    assert all(set(ranks) == {"P1", "P2", "P3"} for ranks in df["seat_ranks"])
     expected = golden_dataset.dataframe["winner"].value_counts().to_dict()
     assert df["winner_seat"].value_counts().to_dict() == expected
 
@@ -32,7 +53,9 @@ def test_ingest_golden_dataset(tmp_path, caplog, golden_dataset):
 def test_curate_golden_dataset(tmp_path, caplog, golden_dataset):
     cfg = PipelineCfg(results_dir=tmp_path)
     golden_dataset.copy_into(cfg.results_dir)
+    raw_path = cfg.ingested_rows_raw(3)
     ingest.run(cfg)
+    assert raw_path.exists()
 
     caplog.set_level(logging.INFO, logger="farkle.analysis.curate")
     curate.run(cfg)
@@ -41,11 +64,15 @@ def test_curate_golden_dataset(tmp_path, caplog, golden_dataset):
     manifest = cfg.manifest_for(3)
     assert curated.exists()
     assert manifest.exists()
+    assert not raw_path.exists()
 
     table = pq.read_table(curated)
     assert table.num_rows == len(golden_dataset.dataframe)
     meta = json.loads(manifest.read_text())
     assert meta["row_count"] == len(golden_dataset.dataframe)
+    assert meta["schema_hash"]
+    assert meta.get("compression") == cfg.parquet_codec
+    assert "created_at" in meta
 
     messages = [rec.message for rec in caplog.records]
     assert any("Curate finished" in msg for msg in messages)
@@ -64,18 +91,42 @@ def test_metrics_golden_dataset(tmp_path, caplog, golden_dataset):
     metrics_path = cfg.analysis_dir / cfg.metrics_name
     seat_csv = cfg.analysis_dir / "seat_advantage.csv"
     seat_parquet = cfg.analysis_dir / "seat_advantage.parquet"
+    stamp_path = cfg.analysis_dir / "metrics.done.json"
 
     assert metrics_path.exists()
     assert seat_csv.exists()
     assert seat_parquet.exists()
+    assert stamp_path.exists()
 
     metrics_df = pq.read_table(metrics_path).to_pandas()
-    expected_wins = golden_dataset.dataframe["winner"].map(
-        {"P1": "Aggro", "P2": "Balanced", "P3": "Cautious"}
-    ).value_counts()
-    wins_by_strategy = metrics_df.set_index("strategy")["wins"].to_dict()
-    assert wins_by_strategy == expected_wins.to_dict()
-    assert set(metrics_df["games"]) == {len(golden_dataset.dataframe)}
+    stamp = json.loads(stamp_path.read_text())
+    expected_input = str(cfg.curated_parquet)
+    assert expected_input in stamp.get("inputs", {})
+    for expected_output in (metrics_path, seat_csv, seat_parquet):
+        assert str(expected_output) in stamp.get("outputs", {})
+    strategy_series = golden_dataset.dataframe["winner"].map(STRATEGY_MAP)
+    expected_wins = strategy_series.value_counts()
+    total_games = len(golden_dataset.dataframe)
+    metrics_by_strategy = metrics_df.set_index("strategy")
+    games_by_strategy = metrics_by_strategy["games"].to_dict()
+    wins_by_strategy = metrics_by_strategy["wins"].to_dict()
+    win_rate = metrics_by_strategy["win_rate"].to_dict()
+    expected_scores = (
+        golden_dataset.dataframe.assign(winner_strategy=strategy_series)
+        .groupby("winner_strategy")
+        .agg({"winning_score": "sum", "n_rounds": "sum"})
+        .rename(columns={"winning_score": "score_sum", "n_rounds": "round_sum"})
+    )
+    for strategy, wins in expected_wins.to_dict().items():
+        assert wins_by_strategy[strategy] == wins
+        assert games_by_strategy[strategy] == total_games
+        assert win_rate[strategy] == pytest.approx(wins / total_games)
+        score_sum = expected_scores.loc[strategy, "score_sum"]
+        round_sum = expected_scores.loc[strategy, "round_sum"]
+        observed = metrics_by_strategy.loc[strategy]
+        assert observed["expected_score"] == pytest.approx(score_sum / total_games)
+        assert observed["mean_score"] == pytest.approx(score_sum / wins)
+        assert observed["mean_rounds"] == pytest.approx(round_sum / wins)
 
     seat_df = pd.read_csv(seat_csv)
     seat_df["seat"] = seat_df["seat"].apply(lambda s: f"P{int(s)}")
@@ -83,6 +134,21 @@ def test_metrics_golden_dataset(tmp_path, caplog, golden_dataset):
     expected_seat_wins = golden_dataset.dataframe["winner"].value_counts().to_dict()
     observed = {seat: seats[seat] for seat in expected_seat_wins}
     assert observed == expected_seat_wins
+    games_by_seat = seat_df.set_index("seat")["games_with_seat"].to_dict()
+    expected_games_per_seat = {
+        f"P{seat}": (total_games if seat <= 3 else 0) for seat in range(1, 13)
+    }
+    assert games_by_seat == expected_games_per_seat
+    seat_from_parquet = (
+        pq.read_table(seat_parquet)
+        .to_pandas()
+        .assign(seat=lambda frame: frame["seat"].apply(lambda s: f"P{int(s)}"))
+    )
+    pd.testing.assert_frame_equal(
+        seat_df.sort_values("seat").reset_index(drop=True),
+        seat_from_parquet.sort_values("seat").reset_index(drop=True),
+        check_dtype=False,
+    )
 
     messages = [rec.message for rec in caplog.records]
     assert any("Metrics leaderboard computed" in msg for msg in messages)


### PR DESCRIPTION
## Summary
- expand the ingest stabilizer to verify winner strategy extraction and seat rankings
- ensure curation removes the raw shard and records updated manifest metadata
- tighten the metrics stabilizer to validate stamp contents, per-strategy aggregates, and seat-advantage parity

## Testing
- pytest tests/unit/analysis_light -vv

------
https://chatgpt.com/codex/tasks/task_e_68cdaafdce14832f90fd3987f08213b7