### PR TITLE
Fix simulation unit tests after refactor

### DIFF
--- a/tests/unit/simulation/test_run_tournament_metrics.py
+++ b/tests/unit/simulation/test_run_tournament_metrics.py
@@ -108,7 +108,7 @@ def test_run_chunk_metrics_row_logging(monkeypatch, tmp_path):
             }
         )
         if batches:
-            recorded["rows"] = batches[0].rows
+            recorded["rows"] = batches[0].to_pylist()
 
     monkeypatch.setattr(rt, "run_streaming_shard", fake_run_streaming_shard)
 
@@ -120,8 +120,10 @@ def test_run_chunk_metrics_row_logging(monkeypatch, tmp_path):
     assert recorded["rows"] == [{"game_seed": 3, "winner_strategy": "S3"}]
     assert recorded["out_path"] == tmp_path / "rows_42_3.parquet"
     assert recorded["manifest_path"] == manifest
-    assert recorded["schema"] == "dummy-schema"
-    assert recorded["batches"] and hasattr(recorded["batches"][0], "rows")
+    assert recorded["schema"] == pa.schema(
+        [("game_seed", pa.int64()), ("winner_strategy", pa.string())]
+    )
+    assert recorded["batches"] and isinstance(recorded["batches"][0], pa.Table)
     assert recorded["extra"] == {
         "path": "rows_42_3.parquet",
         "n_players": None,


### PR DESCRIPTION
## Summary
- update the run_tournament metrics test to introspect pyarrow tables via to_pylist and schema objects
- align watch_game unit tests with the refactored logger name and seed generation, including a stub for spawn_seeds

## Testing
- pytest tests/unit/simulation -q

------
https://chatgpt.com/codex/tasks/task_e_68cdab0ec8e8832f96720048e64a2bb2