### PR TITLE
Add coverage for combine and check validations

### DIFF
--- a/tests/unit/analysis/test_checks.py
+++ b/tests/unit/analysis/test_checks.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from farkle.analysis.analysis_config import expected_schema_for
+from farkle.analysis.checks import check_post_combine, check_pre_metrics
+
+
+def _combined_path(tmp_path: Path) -> tuple[Path, Path]:
+    data_dir = tmp_path / "data"
+    combined_dir = data_dir / "all_n_players_combined"
+    combined_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir, combined_dir / "all_ingested_rows.parquet"
+
+
+def _write_table(path: Path, schema: pa.Schema, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pylist(rows, schema=schema)
+    pq.write_table(table, path)
+
+
+def _write_manifest(
+    data_dir: Path, n_players: int, payload: dict[str, object] | str
+) -> Path:
+    manifest = data_dir / f"{n_players}p" / f"manifest_{n_players}p.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, str):
+        manifest.write_text(payload)
+    else:
+        manifest.write_text(json.dumps(payload))
+    return manifest
+
+
+def test_check_pre_metrics_missing_winner_column(tmp_path: Path) -> None:
+    data_dir, combined = _combined_path(tmp_path)
+    schema = pa.schema([("n_rounds", pa.int16())])
+    _write_table(combined, schema, [{"n_rounds": 1}])
+    _write_manifest(data_dir, 1, {"row_count": 1})
+
+    with pytest.raises(RuntimeError, match="missing 'winner'"):
+        check_pre_metrics(combined)
+
+
+def test_check_pre_metrics_negative_integer_column(tmp_path: Path) -> None:
+    data_dir, combined = _combined_path(tmp_path)
+    schema = pa.schema(
+        [
+            ("winner", pa.string()),
+            ("n_rounds", pa.int16()),
+            ("bad_counts", pa.int32()),
+        ]
+    )
+    _write_table(
+        combined,
+        schema,
+        [{"winner": "P1", "n_rounds": 1, "bad_counts": -3}],
+    )
+    _write_manifest(data_dir, 1, {"row_count": 1})
+
+    with pytest.raises(RuntimeError, match="negative values present"):
+        check_pre_metrics(combined)
+
+
+def test_check_pre_metrics_unreadable_manifest(tmp_path: Path) -> None:
+    data_dir, combined = _combined_path(tmp_path)
+    schema = pa.schema(
+        [
+            ("winner", pa.string()),
+            ("n_rounds", pa.int16()),
+            ("good_counts", pa.int32()),
+        ]
+    )
+    _write_table(
+        combined,
+        schema,
+        [{"winner": "P1", "n_rounds": 1, "good_counts": 5}],
+    )
+    _write_manifest(data_dir, 1, "{not json")
+
+    with pytest.raises(RuntimeError, match="failed to parse"):
+        check_pre_metrics(combined)
+
+
+def test_check_pre_metrics_manifest_row_mismatch(tmp_path: Path) -> None:
+    data_dir, combined = _combined_path(tmp_path)
+    schema = pa.schema(
+        [
+            ("winner", pa.string()),
+            ("n_rounds", pa.int16()),
+            ("good_counts", pa.int32()),
+        ]
+    )
+    _write_table(
+        combined,
+        schema,
+        [
+            {"winner": "P1", "n_rounds": 1, "good_counts": 5},
+            {"winner": "P2", "n_rounds": 1, "good_counts": 6},
+        ],
+    )
+    _write_manifest(data_dir, 1, {"row_count": 1})
+
+    with pytest.raises(RuntimeError, match="row-count mismatch"):
+        check_pre_metrics(combined)
+
+
+def test_check_post_combine_missing_output(tmp_path: Path) -> None:
+    combined = tmp_path / "missing.parquet"
+
+    with pytest.raises(RuntimeError, match="missing"):
+        check_post_combine([], combined)
+
+
+def test_check_post_combine_unreadable_output(tmp_path: Path) -> None:
+    combined = tmp_path / "bad.parquet"
+    combined.write_text("not parquet data")
+
+    with pytest.raises(RuntimeError, match="unable to read"):
+        check_post_combine([], combined)
+
+
+def test_check_post_combine_row_count_mismatch(tmp_path: Path) -> None:
+    schema = expected_schema_for(1)
+    curated = tmp_path / "1p" / "curated.parquet"
+    _write_table(curated, schema, [{"winning_score": 100}])
+
+    combined = tmp_path / "combined.parquet"
+    _write_table(
+        combined,
+        schema,
+        [{"winning_score": 100}, {"winning_score": 200}],
+    )
+
+    with pytest.raises(RuntimeError, match="row-count mismatch"):
+        check_post_combine([curated], combined, max_players=1)
+
+
+def test_check_post_combine_schema_mismatch(tmp_path: Path) -> None:
+    schema = expected_schema_for(1)
+    curated = tmp_path / "1p" / "curated.parquet"
+    _write_table(curated, schema, [{"winning_score": 100}])
+
+    combined = tmp_path / "combined.parquet"
+    wrong_schema = pa.schema([("winner_seat", pa.string())])
+    _write_table(combined, wrong_schema, [{"winner_seat": "P1"}])
+
+    with pytest.raises(RuntimeError, match="output schema mismatch"):
+        check_post_combine([curated], combined, max_players=1)

--- a/tests/unit/analysis/test_combine.py
+++ b/tests/unit/analysis/test_combine.py
@@ -1,6 +1,9 @@
 from pathlib import Path
+import os
+
 import pyarrow as pa
 import pyarrow.parquet as pq
+
 from farkle.analysis.analysis_config import PipelineCfg, expected_schema_for
 from farkle.analysis import combine
 
@@ -11,7 +14,7 @@ def _write_curated(path: Path, schema: pa.Schema, rows: list[dict]) -> None:
     pq.write_table(tbl, path)
 
 
-def test_combine_pads_and_counts(tmp_results_dir: Path) -> None:
+def test_combine_pads_and_counts(tmp_results_dir: Path, capinfo, monkeypatch) -> None:
     cfg = PipelineCfg(results_dir=tmp_results_dir)
     # create per-N curated files
     p1 = cfg.ingested_rows_curated(1)
@@ -24,9 +27,106 @@ def test_combine_pads_and_counts(tmp_results_dir: Path) -> None:
     _write_curated(p2, schema2, [
         {"winner": "P1", "n_rounds": 1, "winning_score": 200, "P1_strategy": "A", "P2_strategy": "B", "P1_rank": 1, "P2_rank": 2},
     ])
+    calls: list[tuple[list[Path], Path, int]] = []
+
+    def _capture(files: list[Path], combined: Path, max_players: int = 12) -> None:
+        calls.append((files, combined, max_players))
+
+    monkeypatch.setattr(combine, "check_post_combine", _capture)
+
     # run combine
     combine.run(cfg)
     out = cfg.data_dir / "all_n_players_combined" / "all_ingested_rows.parquet"
     pf = pq.ParquetFile(out)
     assert pf.metadata.num_rows == 2
     assert pq.read_schema(out).names == expected_schema_for(12).names
+    log = next(rec for rec in capinfo.records if rec.message == "Combine: parquet written")
+    assert getattr(log, "stage", None) == "combine"
+    assert getattr(log, "path", "") == str(out)
+    assert getattr(log, "rows", None) == 2
+    manifest_path = out.with_suffix(".manifest.jsonl")
+    assert manifest_path.exists()
+    assert calls and calls[0][0] == [p1, p2]
+    assert calls[0][1] == out
+    assert calls[0][2] == 12
+
+
+def test_combine_logs_when_no_inputs(tmp_results_dir: Path, capinfo, monkeypatch) -> None:
+    cfg = PipelineCfg(results_dir=tmp_results_dir)
+    calls: list[tuple[list[Path], Path, int]] = []
+
+    monkeypatch.setattr(
+        combine,
+        "check_post_combine",
+        lambda *args, **kwargs: calls.append(([], Path(), 0)),
+    )
+
+    combine.run(cfg)
+
+    assert any(
+        rec.message == "Combine: no inputs discovered" and getattr(rec, "stage", None) == "combine"
+        for rec in capinfo.records
+    )
+    assert not calls
+
+
+def test_combine_skips_when_output_newer(tmp_results_dir: Path, capinfo, monkeypatch) -> None:
+    cfg = PipelineCfg(results_dir=tmp_results_dir)
+    calls: list[tuple[list[Path], Path, int]] = []
+
+    monkeypatch.setattr(
+        combine,
+        "check_post_combine",
+        lambda *args, **kwargs: calls.append(([], Path(), 0)),
+    )
+
+    schema = pa.schema([("winner", pa.string())])
+    input_path = cfg.ingested_rows_curated(1)
+    _write_curated(input_path, schema, [{"winner": "P1"}])
+
+    out_dir = cfg.data_dir / "all_n_players_combined"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / "all_ingested_rows.parquet"
+    pq.write_table(pa.Table.from_pylist([{"winner": "P1"}], schema=schema), out)
+    os.utime(input_path, (0, 0))
+
+    combine.run(cfg)
+
+    assert any(
+        rec.message == "Combine: output up-to-date" and getattr(rec, "stage", None) == "combine"
+        for rec in capinfo.records
+    )
+    assert not calls
+
+
+def test_combine_zero_row_inputs_cleanup(tmp_results_dir: Path, capinfo, monkeypatch) -> None:
+    cfg = PipelineCfg(results_dir=tmp_results_dir)
+    calls: list[tuple[list[Path], Path, int]] = []
+
+    monkeypatch.setattr(
+        combine,
+        "check_post_combine",
+        lambda *args, **kwargs: calls.append(([], Path(), 0)),
+    )
+
+    schema = expected_schema_for(1)
+    input_path = cfg.ingested_rows_curated(1)
+    _write_curated(input_path, schema, [])
+
+    out_dir = cfg.data_dir / "all_n_players_combined"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / "all_ingested_rows.parquet"
+    out.write_text("stale")
+    manifest = out.with_suffix(".manifest.jsonl")
+    manifest.write_text("old")
+    os.utime(out, (0, 0))
+
+    combine.run(cfg)
+
+    assert any(
+        rec.message == "Combine: inputs produced zero rows" and getattr(rec, "stage", None) == "combine"
+        for rec in capinfo.records
+    )
+    assert not out.exists()
+    assert not manifest.exists()
+    assert not calls


### PR DESCRIPTION
## Summary
- add regression tests for `check_pre_metrics` and `check_post_combine` covering missing metadata, negative counts, malformed manifests, and schema mismatches
- extend the combine unit suite to exercise logging-only paths, zero-row cleanup, the up-to-date guard, and the invocation of `check_post_combine`

## Testing
- pytest tests/unit/analysis/test_checks.py tests/unit/analysis/test_combine.py

------
https://chatgpt.com/codex/tasks/task_e_68ce6d2f8bfc832fb1ce3f08da3f1b05