### PR TITLE
Add run_trueskill streaming and orchestration tests

### DIFF
--- a/src/farkle/analysis/ingest.py
+++ b/src/farkle/analysis/ingest.py
@@ -290,7 +290,7 @@ def run(cfg: AppConfig | PipelineCfg) -> None:
 
     blocks = sorted(
         (p for p in cfg.results_dir.iterdir() if p.is_dir() and p.name.endswith("_players")),
-        key=lambda p: _n_from_block(p.name),
+        key=lambda p: (_n_from_block(p.name), p.name),
     )
 
     total_rows = 0

--- a/tests/unit/analysis/test_run_trueskill_orchestration.py
+++ b/tests/unit/analysis/test_run_trueskill_orchestration.py
@@ -1,0 +1,142 @@
+import json
+import math
+import os
+from pathlib import Path
+from typing import Dict, Tuple
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import farkle.analysis.run_trueskill as rt
+
+
+def test_run_trueskill_pooling_and_short_circuit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data_root = tmp_path / "results"
+    block2 = data_root / "2_players"
+    block3 = data_root / "3_players"
+    block2.mkdir(parents=True, exist_ok=True)
+    block3.mkdir(parents=True, exist_ok=True)
+
+    analysis_root = tmp_path / "analysis"
+
+    per_block: Dict[str, Tuple[dict[str, rt.RatingStats], int]] = {
+        "2": (
+            {
+                "A": rt.RatingStats(20.0, 2.0),
+                "B": rt.RatingStats(15.0, 1.5),
+            },
+            5,
+        ),
+        "3": (
+            {
+                "A": rt.RatingStats(40.0, 4.0),
+                "C": rt.RatingStats(30.0, 3.0),
+            },
+            15,
+        ),
+    }
+
+    def immediate_write(table: pa.Table, path: Path | str, *, codec: str = "snappy") -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        pq.write_table(table, path, compression=codec)
+
+    created_executors: list["_FakeExecutor"] = []
+
+    class _FakeFuture:
+        def __init__(self, fn, args, kwargs):
+            try:
+                self._result = fn(*args, **kwargs)
+                self._error = None
+            except Exception as exc:  # pragma: no cover - defensive
+                self._result = None
+                self._error = exc
+
+        def result(self):
+            if self._error is not None:  # pragma: no cover - defensive
+                raise self._error
+            return self._result
+
+    class _FakeExecutor:
+        def __init__(self, max_workers: int):
+            self.max_workers = max_workers
+            self.submissions = []
+            created_executors.append(self)
+
+        def submit(self, fn, *args, **kwargs):
+            self.submissions.append((fn, args, kwargs))
+            return _FakeFuture(fn, args, kwargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_as_completed(futures):
+        return list(futures)
+
+    def fake_rate_block_worker(
+        block_dir: str,
+        root_dir: str,
+        suffix: str,
+        batch_rows: int,
+        *,
+        resume: bool,
+        checkpoint_every_batches: int,
+        env_kwargs: dict | None,
+    ) -> tuple[str, int]:
+        player_count = Path(block_dir).name.split("_")[0]
+        stats, games = per_block[player_count]
+        out_path = Path(root_dir) / f"ratings_{player_count}{suffix}.parquet"
+        if not out_path.exists():
+            rt._save_ratings_parquet(out_path, stats)
+        return player_count, games
+
+    tier_calls: list[tuple[dict[str, float], dict[str, float]]] = []
+
+    def fake_build_tiers(means: dict[str, float], stdevs: dict[str, float]) -> dict[str, int]:
+        tier_calls.append((means, stdevs))
+        return {name: idx + 1 for idx, name in enumerate(sorted(means))}
+
+    monkeypatch.setattr(rt, "write_parquet_atomic", immediate_write)
+    monkeypatch.setattr(rt.cf, "ProcessPoolExecutor", _FakeExecutor)
+    monkeypatch.setattr(rt.cf, "as_completed", fake_as_completed)
+    monkeypatch.setattr(rt, "_rate_block_worker", fake_rate_block_worker)
+    monkeypatch.setattr(rt, "build_tiers", fake_build_tiers)
+    monkeypatch.setattr(rt.os, "cpu_count", lambda: 2)
+
+    rt.run_trueskill(root=analysis_root, dataroot=data_root, workers=8)
+
+    assert created_executors and created_executors[0].max_workers == 2
+
+    pooled_path = analysis_root / "ratings_pooled.parquet"
+    json_path = analysis_root / "ratings_pooled.json"
+    tiers_path = analysis_root / "tiers.json"
+    assert pooled_path.exists() and json_path.exists() and tiers_path.exists()
+
+    pooled = rt._load_ratings_parquet(pooled_path)
+    assert pooled.keys() == {"A", "B", "C"}
+    assert pooled["A"].mu == pytest.approx(1000.0 / 35.0)
+    assert pooled["A"].sigma == pytest.approx(math.sqrt(16.0 / 35.0))
+    assert pooled["B"].mu == pytest.approx(15.0)
+    assert pooled["B"].sigma == pytest.approx(math.sqrt(9.0 / 20.0))
+    assert pooled["C"].mu == pytest.approx(30.0)
+    assert pooled["C"].sigma == pytest.approx(math.sqrt(3.0 / 5.0))
+
+    pooled_json = json.loads(json_path.read_text())
+    for key, stats in pooled.items():
+        assert pooled_json[key]["mu"] == pytest.approx(stats.mu)
+        assert pooled_json[key]["sigma"] == pytest.approx(stats.sigma)
+
+    assert tier_calls and tiers_path.read_text()
+
+    before = pooled_path.stat().st_mtime + 10.0
+    os.utime(pooled_path, (before, before))
+    tier_calls.clear()
+
+    rt.run_trueskill(root=analysis_root, dataroot=data_root, workers=8)
+
+    assert not tier_calls
+    assert pooled_path.stat().st_mtime == before

--- a/tests/unit/analysis/test_run_trueskill_streaming.py
+++ b/tests/unit/analysis/test_run_trueskill_streaming.py
@@ -1,0 +1,278 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import trueskill
+
+import farkle.analysis.run_trueskill as rt
+
+
+class _DummyRating:
+    def __init__(self, mu: float = 0.0, sigma: float = 1.0) -> None:
+        self.mu = mu
+        self.sigma = sigma
+
+
+class _DummyEnv:
+    def __init__(self) -> None:
+        self.rate_calls: list[list[int]] = []
+
+    def create_rating(self, mu: float = 0.0, sigma: float = 1.0) -> _DummyRating:
+        return _DummyRating(mu, sigma)
+
+    def rate(self, teams: list[list[_DummyRating]], ranks: list[int]) -> list[list[_DummyRating]]:
+        self.rate_calls.append(list(ranks))
+        result: list[list[_DummyRating]] = []
+        for team, rank in zip(teams, ranks, strict=True):
+            base = team[0]
+            result.append([_DummyRating(float(rank), base.sigma)])
+        return result
+
+
+@pytest.fixture()
+def sample_parquet(tmp_path: Path) -> Path:
+    table = pa.table(
+        {
+            "winner_seat": ["P1", "P2", "P1", "P2", "P1"],
+            "P1_strategy": ["A", "B", "C", "D", "E"],
+            "P2_strategy": ["B", "C", "D", "E", "F"],
+        }
+    )
+    path = tmp_path / "games.parquet"
+    pq.write_table(table, path, row_group_size=3)
+    return path
+
+
+def test_stream_batches_respects_resume_offsets(sample_parquet: Path) -> None:
+    batches = list(
+        rt._stream_batches(
+            sample_parquet,
+            ["winner_seat", "P1_strategy", "P2_strategy"],
+            batch_rows=2,
+        )
+    )
+    assert [(rg, bi, batch.num_rows) for rg, bi, batch in batches] == [
+        (0, 0, 2),
+        (0, 1, 1),
+        (1, 0, 2),
+    ]
+    assert batches[0][2].column("P1_strategy").to_pylist() == ["A", "B"]
+
+    resumed = list(
+        rt._stream_batches(
+            sample_parquet,
+            ["winner_seat", "P1_strategy"],
+            start_row_group=0,
+            start_batch_idx=1,
+            batch_rows=2,
+        )
+    )
+    assert [(rg, bi) for rg, bi, _ in resumed] == [(0, 1), (1, 0)]
+    assert resumed[0][2].column("P1_strategy").to_pylist() == ["C"]
+
+    later_groups = list(
+        rt._stream_batches(
+            sample_parquet,
+            ["winner_seat"],
+            start_row_group=1,
+            batch_rows=2,
+        )
+    )
+    assert [(rg, bi, batch.num_rows) for rg, bi, batch in later_groups] == [(1, 0, 2)]
+
+
+def test_players_and_ranks_precedence(tmp_path: Path) -> None:
+    seat_ranks = pa.array(
+        [
+            ["P3", "P2", "P1"],
+            ["P2", "P1"],
+            None,
+        ],
+        type=pa.list_(pa.string()),
+    )
+    table = pa.table(
+        {
+            "seat_ranks": seat_ranks,
+            "winner": ["P3", "P2", "P3"],
+            "P1_strategy": ["alpha", "delta", "zeta"],
+            "P2_strategy": ["beta", "epsilon", "eta"],
+            "P3_strategy": ["gamma", None, "theta"],
+            "P1_rank": pa.array([1, None, None], type=pa.int64()),
+            "P2_rank": pa.array([1, None, None], type=pa.int64()),
+            "P3_rank": pa.array([2, None, None], type=pa.int64()),
+        }
+    )
+    path = tmp_path / "precedence.parquet"
+    pq.write_table(table, path, row_group_size=3)
+
+    batch = next(
+        rt._stream_batches(
+            path,
+            list(table.schema.names),
+            batch_rows=10,
+        )
+    )[2]
+    rows = list(rt._players_and_ranks_from_batch(batch, 3))
+    assert rows == [
+        (["alpha", "beta", "gamma"], [0, 0, 1]),
+        (["epsilon", "delta"], [0, 1]),
+        (["theta", "zeta", "eta"], [0, 1, 1]),
+    ]
+
+
+def test_rate_single_pass_resumes_from_checkpoint(tmp_path: Path) -> None:
+    env = trueskill.TrueSkill()
+    table = pa.table(
+        {
+            "winner_seat": ["P1", "P2"],
+            "P1_strategy": ["A", "B"],
+            "P2_strategy": ["B", "C"],
+            "P1_rank": pa.array([0, 1], type=pa.int64()),
+            "P2_rank": pa.array([1, 0], type=pa.int64()),
+        }
+    )
+    source = tmp_path / "combined.parquet"
+    pq.write_table(table, source, row_group_size=1)
+
+    ratings_ck = tmp_path / "ratings.checkpoint.parquet"
+    rt._save_ratings_parquet(ratings_ck, {"B": env.create_rating(mu=33.0, sigma=7.0)})
+    ck_path = tmp_path / "ratings.ckpt.json"
+    rt._save_ckpt(
+        ck_path,
+        rt._TSCheckpoint(
+            source=str(source),
+            row_group=1,
+            batch_index=0,
+            games_done=3,
+            ratings_path=str(ratings_ck),
+        ),
+    )
+
+    stats, games = rt._rate_single_pass(
+        source=source,
+        env=env,
+        resume=True,
+        checkpoint_path=ck_path,
+        ratings_ckpt_path=ratings_ck,
+        batch_rows=1,
+        checkpoint_every_batches=1,
+    )
+    assert games == 4
+    assert set(stats) == {"B", "C"}
+    assert "A" not in stats
+
+    updated = json.loads(ck_path.read_text())
+    assert updated["row_group"] == 1
+    assert updated["batch_index"] == 1
+    assert updated["games_done"] == games
+
+    interim = rt._load_ratings_parquet(ratings_ck)
+    assert set(interim) == {"B", "C"}
+
+
+def test_rate_block_worker_resumes_from_checkpoint(tmp_path: Path) -> None:
+    root = tmp_path / "analysis"
+    data_dir = root / "data" / "2p"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    block_dir = tmp_path / "results" / "2_players"
+    block_dir.mkdir(parents=True, exist_ok=True)
+    np.save(block_dir / "keepers_2.npy", np.array(["A", "C"]))
+
+    table = pa.table(
+        {
+            "winner_seat": ["P1", "P2"],
+            "P1_strategy": ["A", "A"],
+            "P2_strategy": ["B", "C"],
+            "P1_rank": pa.array([0, 0], type=pa.int64()),
+            "P2_rank": pa.array([1, 2], type=pa.int64()),
+        }
+    )
+    row_file = data_dir / "2p_ingested_rows.parquet"
+    pq.write_table(table, row_file, row_group_size=1)
+
+    ratings_ck = root / "ratings_2.checkpoint.parquet"
+    rt._save_ratings_parquet(ratings_ck, {"A": trueskill.TrueSkill().create_rating(mu=25.0, sigma=8.0)})
+    ck_path = root / "ratings_2.ckpt.json"
+    rt._save_block_ckpt(
+        ck_path,
+        rt._BlockCkpt(
+            row_file=str(row_file),
+            row_group=1,
+            batch_index=0,
+            games_done=7,
+            ratings_path=str(ratings_ck),
+        ),
+    )
+
+    player_count, games = rt._rate_block_worker(
+        str(block_dir),
+        str(root),
+        "",
+        batch_rows=1,
+        resume=True,
+        checkpoint_every_batches=1,
+    )
+    assert player_count == "2"
+    assert games == 8
+
+    ratings = rt._load_ratings_parquet(root / "ratings_2.parquet")
+    assert set(ratings) == {"A", "C"}
+    assert "B" not in ratings
+
+    updated = json.loads(ck_path.read_text())
+    assert updated["row_group"] == 1
+    assert updated["batch_index"] == 1
+    assert updated["games_done"] == games
+
+    interim = rt._load_ratings_parquet(ratings_ck)
+    assert set(interim) == {"A", "C"}
+
+
+def test_coerce_and_seed_ratings() -> None:
+    mapping: dict[str, Any] = {
+        "A": rt.RatingStats(1.0, 2.0),
+        "B": {"mu": 3.0, "sigma": 4.0},
+        "C": (5.0, 6.0),
+        "D": [7.0, 8.0, 9.0],
+        "E": 10.0,
+    }
+    coerced = rt._coerce_ratings(mapping)
+    assert coerced["A"] == rt.RatingStats(1.0, 2.0)
+    assert coerced["B"] == rt.RatingStats(3.0, 4.0)
+    assert coerced["C"] == rt.RatingStats(5.0, 6.0)
+    assert coerced["D"] == rt.RatingStats(7.0, 8.0)
+    assert coerced["E"] == rt.RatingStats(0.0, 0.0)
+
+    env = _DummyEnv()
+    ratings = {"A": _DummyRating(0.5, 0.1)}
+    rt._ensure_seed_ratings(ratings, ["A", "B"], env)  # type: ignore[arg-type]
+    assert {"A", "B"} <= set(ratings)
+    assert isinstance(ratings["B"], _DummyRating)
+
+
+def test_rate_stream_applies_keeper_filter(tmp_path: Path) -> None:
+    env = _DummyEnv()
+    table = pa.table(
+        {
+            "winner": ["P1"],
+            "P1_strategy": ["A"],
+            "P2_strategy": ["B"],
+            "P3_strategy": ["C"],
+            "P1_rank": pa.array([0], type=pa.int64()),
+            "P2_rank": pa.array([2], type=pa.int64()),
+            "P3_rank": pa.array([5], type=pa.int64()),
+        }
+    )
+    path = tmp_path / "stream.parquet"
+    pq.write_table(table, path)
+
+    ratings, games = rt._rate_stream(path, 3, ["A", "C"], env, batch_size=1)
+    assert games == 1
+    assert env.rate_calls == [[0, 1]]
+    assert set(ratings) == {"A", "C"}
+    assert ratings["A"].mu == 0.0
+    assert ratings["C"].mu == 1.0


### PR DESCRIPTION
## Summary
- add coverage for run_trueskill streaming helpers and checkpoint logic
- exercise run_trueskill orchestration with patched executors and pooling checks
- stub matplotlib/sklearn for unit tests and make ingest block ordering deterministic when names tie

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce6d37e138832f8b180ab5a79e9c09