### PR TITLE
Add tests for config helper coercion and override errors

### DIFF
--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional, Union
 
+import pytest
 import yaml
 
-from farkle.config import AppConfig, apply_dot_overrides, load_app_config
+from farkle.config import (
+    AppConfig,
+    _annotation_contains,
+    _coerce,
+    apply_dot_overrides,
+    load_app_config,
+)
 
 
 BASE_CFG = Path("configs/base.yaml")
@@ -56,3 +64,101 @@ def test_apply_dot_overrides(tmp_path: Path) -> None:
     assert cfg.analysis.trueskill_beta == 3.5
     assert cfg.analysis.n_jobs == 4
     assert cfg.analysis.log_level == "DEBUG"
+
+
+@pytest.mark.parametrize(
+    ("annotation", "target", "expected"),
+    [
+        (Optional[Union[int, Path]], Path, True),
+        (Union[str, Optional[Union[int, Path]]], Path, True),
+        (Optional[Union[int, str]], Path, False),
+        (Union[Optional[int], Union[str, Optional[Path]]], Path, True),
+    ],
+)
+def test_annotation_contains_nested(annotation: object, target: type, expected: bool) -> None:
+    assert _annotation_contains(annotation, target) is expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("true", True),
+        ("false", False),
+        ("YES", True),
+        ("0", False),
+    ],
+)
+def test_coerce_boolean_like_strings(raw: str, expected: bool) -> None:
+    assert _coerce(raw, current=True) is expected
+
+
+@pytest.mark.parametrize("raw", ["1", "off"])
+def test_coerce_boolean_with_annotation(raw: str) -> None:
+    expected = raw.lower() in {"1", "true", "yes", "on"}
+    assert _coerce(raw, current="", annotation=Optional[bool]) is expected
+
+
+def test_coerce_boolean_invalid() -> None:
+    with pytest.raises(ValueError):
+        _coerce("maybe", current=False)
+
+
+def test_coerce_int_from_current() -> None:
+    assert _coerce("42", current=1) == 42
+
+
+def test_coerce_int_from_annotation() -> None:
+    result = _coerce("7", current=None, annotation=Optional[int])
+    assert isinstance(result, int)
+    assert result == 7
+
+
+def test_coerce_float_from_current() -> None:
+    assert _coerce("3.14", current=0.0) == pytest.approx(3.14)
+
+
+def test_coerce_float_from_annotation() -> None:
+    result = _coerce("2.5", current=None, annotation=Optional[float])
+    assert isinstance(result, float)
+    assert result == pytest.approx(2.5)
+
+
+def test_coerce_path_from_current() -> None:
+    result = _coerce("foo/bar", current=Path("baz"))
+    assert isinstance(result, Path)
+    assert result == Path("foo/bar")
+
+
+def test_coerce_path_from_annotation() -> None:
+    result = _coerce("nested/data", current=None, annotation=Optional[Path])
+    assert isinstance(result, Path)
+    assert result == Path("nested/data")
+
+
+def test_coerce_passthrough_string() -> None:
+    assert _coerce("value", current="existing") == "value"
+
+
+def test_apply_dot_overrides_missing_equals() -> None:
+    cfg = load_app_config(BASE_CFG)
+    with pytest.raises(ValueError, match="Invalid override"):
+        apply_dot_overrides(cfg, ["sim.n_players"])
+
+
+def test_apply_dot_overrides_missing_section_separator() -> None:
+    cfg = load_app_config(BASE_CFG)
+    with pytest.raises(ValueError, match="Invalid override"):
+        apply_dot_overrides(cfg, ["n_players=3"])
+
+
+def test_apply_dot_overrides_unknown_option() -> None:
+    cfg = load_app_config(BASE_CFG)
+    with pytest.raises(AttributeError, match="Unknown option"):
+        apply_dot_overrides(cfg, ["sim.unknown=1"])
+
+
+def test_apply_dot_overrides_relative_path_override() -> None:
+    cfg = load_app_config(BASE_CFG)
+    apply_dot_overrides(cfg, ["sim.row_dir=rows/output"])
+    assert isinstance(cfg.sim.row_dir, Path)
+    assert cfg.sim.row_dir == Path("rows/output")


### PR DESCRIPTION
## Summary
- add parameterized coverage for `_annotation_contains` with nested Union/Optional hints
- exercise `_coerce` conversions for boolean-like values, ints, floats, and paths including error cases
- verify `apply_dot_overrides` error handling and successful relative path overrides

## Testing
- pytest tests/unit/test_app_config.py

------
https://chatgpt.com/codex/tasks/task_e_68ce6d462f34832fbe72c10653861d4e