### PR TITLE
Add run_tournament chunking and checkpoint tests

### DIFF
--- a/tests/unit/simulation/test_run_tournament_metrics.py
+++ b/tests/unit/simulation/test_run_tournament_metrics.py
@@ -49,6 +49,8 @@ sys.modules.setdefault("scipy.stats", scipy_stats_stub)  # type: ignore
 import pyarrow as pa
 import pyarrow.parquet as pq
 import farkle.simulation.run_tournament as rt
+from farkle.simulation.strategies import ThresholdStrategy
+from farkle.utils import manifest
 
 
 @pytest.fixture(autouse=True)
@@ -70,6 +72,46 @@ def _fake_play_one_shuffle(seed: int, *, collect_rows: bool = False):
     sq = {label: defaultdict(float, {winner: float(seed * seed)}) for label in rt.METRIC_LABELS}
     rows = [{"game_seed": seed, "winner_strategy": winner}] if collect_rows else []
     return wins, sums, sq, rows
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for run_tournament tests
+# ---------------------------------------------------------------------------
+
+
+def _mini_strategies(count: int = 6) -> list[ThresholdStrategy]:
+    return [ThresholdStrategy(40 + 5 * i, i % 3, True, True) for i in range(count)]
+
+
+def _install_serial_process_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_process_map(func, iterable, *, initializer=None, initargs=(), **kwargs):
+        if initializer is not None:
+            initializer(*initargs)
+        for item in iterable:
+            yield func(item)
+
+    monkeypatch.setattr(rt.parallel, "process_map", fake_process_map)
+
+
+def _setup_serial_run(monkeypatch: pytest.MonkeyPatch) -> list[ThresholdStrategy]:
+    strategies = _mini_strategies()
+    monkeypatch.setattr(
+        rt, "generate_strategy_grid", lambda *a, **kw: (strategies, None), raising=True
+    )
+
+    def fake_measure(sample_strategies, sample_games: int = 2_000, seed: int = 0) -> float:  # noqa: ARG001
+        n_players = max(1, len(sample_strategies))
+        return 8_160 / n_players
+
+    monkeypatch.setattr(rt, "_measure_throughput", fake_measure, raising=True)
+    monkeypatch.setattr(
+        rt.urandom,
+        "spawn_seeds",
+        lambda count, seed=0: list(range(seed, seed + count)),
+        raising=True,
+    )
+    _install_serial_process_map(monkeypatch)
+    return strategies
 
 
 # ---------------------------------------------------------------------------
@@ -158,4 +200,190 @@ def test_save_checkpoint_wins_only(tmp_path):
     payload = pickle.loads(ckpt.read_bytes())
 
     assert payload == {"win_totals": wins}
+
+
+def test_run_tournament_metric_chunks_round_trip(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    _setup_serial_run(monkeypatch)
+    monkeypatch.setattr(rt, "_play_one_shuffle", _fake_play_one_shuffle, raising=True)
+
+    checkpoint_path = tmp_path / "run" / "checkpoint.pkl"
+    metrics_dir = tmp_path / "metrics"
+    row_dir = tmp_path / "rows"
+
+    config = rt.TournamentConfig(n_players=2, desired_sec_per_chunk=1, ckpt_every_sec=9999)
+
+    rt.run_tournament(
+        config=config,
+        global_seed=0,
+        checkpoint_path=checkpoint_path,
+        n_jobs=1,
+        collect_metrics=True,
+        row_output_directory=row_dir,
+        metric_chunk_directory=metrics_dir,
+        num_shuffles=3,
+    )
+
+    chunk_files = sorted(metrics_dir.glob("metrics_*.parquet"))
+    assert len(chunk_files) == 3
+
+    metrics_manifest = metrics_dir / "metrics_manifest.jsonl"
+    metric_records = list(manifest.iter_manifest(metrics_manifest))
+    assert len(metric_records) == 3
+    assert {record["path"] for record in metric_records} == {f.name for f in chunk_files}
+
+    row_files = list(row_dir.glob("rows_*.parquet"))
+    assert len(row_files) == 3
+    row_records = list(manifest.iter_manifest(row_dir / "manifest.jsonl"))
+    assert len(row_records) == 3
+    assert all(record.get("rows") == 1 for record in row_records)
+
+    metrics_path = checkpoint_path.with_name("2p_metrics.parquet")
+    table = pq.read_table(metrics_path)
+    assert table.num_rows == len(rt.METRIC_LABELS) * 3
+    metrics_rows = {(
+        row["metric"],
+        row["strategy"],
+    ): (row["sum"], row["square_sum"]) for row in table.to_pylist()}
+    for seed in range(3):
+        for label in rt.METRIC_LABELS:
+            assert metrics_rows[(label, f"S{seed}")] == (float(seed), float(seed * seed))
+
+
+def test_run_tournament_checkpoint_cadence(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    _setup_serial_run(monkeypatch)
+    monkeypatch.setattr(rt, "_play_one_shuffle", _fake_play_one_shuffle, raising=True)
+
+    metrics_dir = tmp_path / "metrics"
+    checkpoint_path = tmp_path / "ckpt.pkl"
+
+    calls: list[tuple[Path, Counter[str], object, object]] = []
+
+    def fake_save_checkpoint(path: Path, wins, sums, sqs):  # noqa: ANN001
+        calls.append((Path(path), wins.copy(), sums, sqs))
+
+    monkeypatch.setattr(rt, "_save_checkpoint", fake_save_checkpoint, raising=True)
+
+    perf_state = {"value": -15.0}
+
+    def fake_perf_counter():
+        perf_state["value"] += 15.0
+        return perf_state["value"]
+
+    monkeypatch.setattr(rt.time, "perf_counter", fake_perf_counter, raising=True)
+    monkeypatch.setattr(rt.time, "sleep", lambda *a, **k: None, raising=True)
+
+    config = rt.TournamentConfig(n_players=2, desired_sec_per_chunk=1, ckpt_every_sec=10)
+
+    rt.run_tournament(
+        config=config,
+        global_seed=0,
+        checkpoint_path=checkpoint_path,
+        n_jobs=1,
+        collect_metrics=True,
+        metric_chunk_directory=metrics_dir,
+        num_shuffles=2,
+    )
+
+    assert len(calls) >= 3  # two in-loop checkpoints plus the final flush
+    mid_run_calls = calls[:-1]
+    assert all(call[2] is None and call[3] is None for call in mid_run_calls)
+    final_path, final_wins, final_sums, final_sq = calls[-1]
+    assert final_path == checkpoint_path
+    assert isinstance(final_wins, Counter)
+    assert final_sums is not None and final_sq is not None
+
+
+def test_run_tournament_reuses_existing_metric_chunks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    _setup_serial_run(monkeypatch)
+    monkeypatch.setattr(rt, "_play_one_shuffle", _fake_play_one_shuffle, raising=True)
+
+    metrics_dir = tmp_path / "metrics"
+    metrics_dir.mkdir()
+
+    pre_rows = [
+        {
+            "metric": label,
+            "strategy": "S_pre",
+            "sum": 5.0,
+            "square_sum": 25.0,
+        }
+        for label in rt.METRIC_LABELS
+    ]
+    pq.write_table(pa.Table.from_pylist(pre_rows), metrics_dir / "metrics_000010.parquet")
+
+    checkpoint_path = tmp_path / "run" / "checkpoint.pkl"
+    config = rt.TournamentConfig(n_players=2, desired_sec_per_chunk=1, ckpt_every_sec=9999)
+
+    rt.run_tournament(
+        config=config,
+        global_seed=0,
+        checkpoint_path=checkpoint_path,
+        n_jobs=1,
+        collect_metrics=True,
+        metric_chunk_directory=metrics_dir,
+        num_shuffles=1,
+    )
+
+    produced_chunks = sorted(metrics_dir.glob("metrics_*.parquet"))
+    assert any(path.name == "metrics_000001.parquet" for path in produced_chunks)
+
+    metrics_path = checkpoint_path.with_name("2p_metrics.parquet")
+    table = pq.read_table(metrics_path)
+    rows = {(row["metric"], row["strategy"]): row for row in table.to_pylist()}
+    for label in rt.METRIC_LABELS:
+        assert rows[(label, "S_pre")]["sum"] == 5.0
+        assert rows[(label, "S_pre")]["square_sum"] == 25.0
+        assert rows[(label, "S0")]["sum"] == 0.0
+        assert rows[(label, "S0")]["square_sum"] == 0.0
+
+
+def test_run_tournament_no_metrics_wins_only_checkpoint(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    _setup_serial_run(monkeypatch)
+
+    def fake_play_shuffle(seed: int) -> Counter[str]:
+        return Counter({f"S{seed}": 1})
+
+    monkeypatch.setattr(rt, "_play_shuffle", fake_play_shuffle, raising=True)
+
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    config = rt.TournamentConfig(n_players=2, desired_sec_per_chunk=1, ckpt_every_sec=9999)
+
+    calls: list[tuple[Path, Counter[str], object, object]] = []
+
+    def fake_save_checkpoint(path: Path, wins, sums, sqs):  # noqa: ANN001
+        calls.append((Path(path), wins.copy(), sums, sqs))
+
+    monkeypatch.setattr(rt, "_save_checkpoint", fake_save_checkpoint, raising=True)
+
+    debug_logs: list[tuple[str, dict[str, object] | None]] = []
+
+    def fake_debug(msg: str, *args, **kwargs):
+        debug_logs.append((msg, kwargs.get("extra")))
+
+    monkeypatch.setattr(rt.LOGGER, "debug", fake_debug)
+
+    rt.run_tournament(
+        config=config,
+        global_seed=0,
+        checkpoint_path=checkpoint_path,
+        n_jobs=1,
+        collect_metrics=False,
+        num_shuffles=2,
+    )
+
+    assert len(calls) == 1
+    path, wins, sums, sqs = calls[0]
+    assert path == checkpoint_path
+    assert wins == Counter({"S0": 1, "S1": 1})
+    assert sums is None and sqs is None
+
+    chunk_debugs = [extra for msg, extra in debug_logs if msg == "Chunk processed"]
+    assert len(chunk_debugs) == 2
+    for idx, extra in enumerate(chunk_debugs, start=1):
+        assert extra["chunk_index"] == idx
+        assert extra["wins"] == 1
 


### PR DESCRIPTION
## Summary
- add serial execution helpers so run_tournament can be exercised deterministically in unit tests
- verify metric chunk parquet shards, manifests, and final aggregates are produced when collecting metrics and rows
- cover checkpoint cadence, pre-populated shard recombination, and the wins-only checkpoint branch

## Testing
- pytest tests/unit/simulation/test_run_tournament_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68ce6d4d1914832f90fda2ed57cd454f