### PR TITLE
Handle cross-drive manifest paths

### DIFF
--- a/src/farkle/utils/streaming_loop.py
+++ b/src/farkle/utils/streaming_loop.py
@@ -29,10 +29,24 @@ def run_streaming_shard(
         w.write_batches(batch_iter)
     rows = getattr(w, "rows_written", None)
     # On success, append a manifest line
+    manifest_dir = os.path.dirname(manifest_path)
+    if manifest_dir:
+        manifest_dir = os.path.abspath(manifest_dir)
+    else:
+        manifest_dir = os.path.abspath(os.curdir)
+
+    try:
+        rel_path = os.path.relpath(out_path)
+    except ValueError:
+        try:
+            rel_path = os.path.relpath(out_path, start=manifest_dir)
+        except ValueError:
+            rel_path = os.path.abspath(out_path)
+
     append_manifest_line(
         manifest_path,
         {
-            "path": os.path.relpath(out_path),
+            "path": rel_path,
             "rows": rows,
             **(manifest_extra or {}),
         },


### PR DESCRIPTION
## Summary
- ensure streaming shard manifest entries prefer cwd-relative paths but fall back cleanly when paths span drives

## Testing
- pytest tests/unit/utils/test_manifest_streaming_loop.py tests/unit/simulation/test_run_tournament_metrics.py -q
- pytest tests/unit/cli/test_main_cli.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ce7379628c832fbfb9be475c039479