### PR TITLE
Add tests for manifest streaming loop fallbacks

### DIFF
--- a/tests/unit/utils/test_manifest_streaming_loop.py
+++ b/tests/unit/utils/test_manifest_streaming_loop.py
@@ -102,17 +102,85 @@ def test_run_streaming_shard_invocation(tmp_path, monkeypatch):
 
     assert manifest_calls and manifest_calls[0][0] == str(manifest_path)
     manifest_record = manifest_calls[0][1]
-    # Compute relative path from the manifest's directory (matches production code).
-    manifest_dir = os.fspath(Path(manifest_path).parent)
+    # Compute the relative path the same way the production code does.
+    manifest_dir = os.path.abspath(os.fspath(Path(manifest_path).parent))
     try:
-        expected_rel = os.path.relpath(os.fspath(out_path), start=manifest_dir)
+        expected_rel = os.path.relpath(os.fspath(out_path))
     except ValueError:
-        # Cross-drive fallback on Windows: use absolute path
-        expected_rel = os.fspath(out_path)
+        try:
+            expected_rel = os.path.relpath(os.fspath(out_path), start=manifest_dir)
+        except ValueError:
+            # Cross-drive fallback on Windows: use absolute path
+            expected_rel = os.path.abspath(os.fspath(out_path))
     assert manifest_record["path"] == expected_rel
     assert manifest_record["rows"] == sum(tbl.num_rows for tbl in tables)
     for key, value in run_extra.items():
         assert manifest_record[key] == value
+
+
+def test_run_streaming_shard_manifest_path_without_dir(tmp_path, monkeypatch):
+    tables = [
+        pa.table({"value": [1, 2]}),
+        pa.table({"value": [3]}),
+    ]
+    schema = tables[0].schema
+    out_path = tmp_path / "nested" / "out.parquet"
+    out_path_str = os.fspath(out_path)
+    manifest_path = "manifest.ndjson"
+
+    class DummyWriter:
+        def __init__(self, *, out_path, schema, compression, row_group_size):
+            self.rows_written = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def write_batches(self, batch_iterable):
+            for tbl in batch_iterable:
+                self.rows_written += tbl.num_rows
+
+    monkeypatch.setattr(streaming_loop, "ParquetShardWriter", DummyWriter)
+
+    manifest_calls = []
+
+    def fake_append(path, record):
+        manifest_calls.append((path, record))
+
+    monkeypatch.setattr(streaming_loop, "append_manifest_line", fake_append)
+
+    relpath_calls = []
+    real_relpath = os.path.relpath
+
+    def fake_relpath(path, start=os.curdir):
+        relpath_calls.append((path, start))
+        if len(relpath_calls) <= 2:
+            raise ValueError("boom")
+        return real_relpath(path, start=start)
+
+    monkeypatch.setattr(os.path, "relpath", fake_relpath)
+
+    expected_manifest_dir = os.path.abspath(os.curdir)
+    streaming_loop.run_streaming_shard(
+        out_path=out_path_str,
+        manifest_path=manifest_path,
+        schema=schema,
+        batch_iter=iter(tables),
+        row_group_size=10,
+        compression="zstd",
+        manifest_extra=None,
+    )
+
+    assert len(relpath_calls) == 2
+    assert relpath_calls[0] == (out_path_str, os.curdir)
+    assert relpath_calls[1] == (out_path_str, expected_manifest_dir)
+
+    assert manifest_calls and manifest_calls[0][0] == manifest_path
+    manifest_record = manifest_calls[0][1]
+    assert manifest_record["path"] == os.path.abspath(out_path_str)
+    assert manifest_record["rows"] == sum(tbl.num_rows for tbl in tables)
 
 
 def test_writer_thread_forwards_manifest(monkeypatch):
@@ -157,6 +225,27 @@ def test_writer_thread_forwards_manifest(monkeypatch):
     assert captured["manifest_extra"] == manifest_extra
     assert len(captured["batches"]) == len(tables)
     for expected, actual in zip(tables, captured["batches"]):
+        assert actual is expected
+
+
+def test_producer_thread_pushes_all_tables():
+    tables = [
+        pa.table({"value": [1]}),
+        pa.table({"value": [2]}),
+    ]
+
+    pushed = []
+
+    def fake_push(tbl):
+        pushed.append(tbl)
+
+    def mk_batches():
+        return iter(tables)
+
+    streaming_loop.producer_thread(fake_push, mk_batches)
+
+    assert pushed == tables
+    for expected, actual in zip(tables, pushed):
         assert actual is expected
 
 


### PR DESCRIPTION
## Summary
- cover the manifest path fallback when relpath raises to ensure absolute paths are recorded
- align the streaming shard test's relative path expectation with the production logic
- add a focused producer_thread test that verifies each table is pushed

## Testing
- pytest tests/unit/utils/test_manifest_streaming_loop.py

------
https://chatgpt.com/codex/tasks/task_e_68cf9d9a0674832f94eef8aefa684c36