### PR TITLE
Simplify TrueSkill wrapper configuration handling

### DIFF
--- a/src/farkle/analysis/trueskill.py
+++ b/src/farkle/analysis/trueskill.py
@@ -3,24 +3,13 @@ from __future__ import annotations
 import logging
 
 from farkle.analysis import run_trueskill
-from farkle.analysis.analysis_config import PipelineCfg
 from farkle.config import AppConfig
 
 LOGGER = logging.getLogger(__name__)
 
 
-def _pipeline_cfg(cfg: AppConfig | PipelineCfg) -> AppConfig | PipelineCfg:
-    if hasattr(cfg, "results_dir") and hasattr(cfg, "analysis_dir") or isinstance(cfg, PipelineCfg):
-        return cfg
-    elif hasattr(cfg, "analysis") and isinstance(cfg.analysis, PipelineCfg):
-        return cfg.analysis
-    else:
-        return cfg
-
-
-def run(cfg: AppConfig | PipelineCfg) -> None:
+def run(cfg: AppConfig) -> None:
     """Thin wrapper around the legacy script so the new pipeline stays small."""
-    cfg = _pipeline_cfg(cfg)
     out = cfg.analysis_dir / "tiers.json"
     if out.exists() and out.stat().st_mtime >= cfg.curated_parquet.stat().st_mtime:
         LOGGER.info(


### PR DESCRIPTION
## Summary
- remove legacy PipelineCfg handling from the TrueSkill analysis wrapper
- require an AppConfig object when running TrueSkill analysis

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e229c11dac832f936c94f54038e449