### PR TITLE
Refine analysis configuration usage

### DIFF
--- a/src/farkle/analysis/__init__.py
+++ b/src/farkle/analysis/__init__.py
@@ -6,7 +6,6 @@ import importlib
 import logging
 from types import ModuleType
 
-from farkle.analysis.analysis_config import PipelineCfg
 from farkle.config import AppConfig
 
 LOGGER = logging.getLogger(__name__)
@@ -23,52 +22,42 @@ def _optional_import(module: str) -> ModuleType | None:
         return None
 
 
-def _pipeline_cfg(cfg: AppConfig | PipelineCfg) -> AppConfig | PipelineCfg:
-    if hasattr(cfg, "results_dir") and hasattr(cfg, "analysis_dir") or isinstance(cfg, PipelineCfg):
-        return cfg
-    elif hasattr(cfg, "analysis") and isinstance(cfg.analysis, PipelineCfg):
-        return cfg.analysis
-    else:
-        return cfg
-
-
-def run_all(cfg: AppConfig | PipelineCfg) -> None:
+def run_all(cfg: AppConfig) -> None:
     """Run every analytics pass in sequence."""
-    cfg = _pipeline_cfg(cfg)
     LOGGER.info("Analytics: starting all modules", extra={"stage": "analysis"})
     ts_mod = _optional_import("farkle.analysis.trueskill")
-    if cfg.run_trueskill and ts_mod is not None:
+    if cfg.analysis.run_trueskill and ts_mod is not None:
         ts_mod.run(cfg)
     else:
         LOGGER.info(
             "Analytics: skipping trueskill",
             extra={
                 "stage": "analysis",
-                "reason": "run_trueskill=False" if not cfg.run_trueskill else "unavailable",
+                "reason": "run_trueskill=False" if not cfg.analysis.run_trueskill else "unavailable",
             },
         )
 
     h2h_mod = _optional_import("farkle.analysis.head2head")
-    if cfg.run_head2head and h2h_mod is not None:
+    if cfg.analysis.run_head2head and h2h_mod is not None:
         h2h_mod.run(cfg)
     else:
         LOGGER.info(
             "Analytics: skipping head-to-head",
             extra={
                 "stage": "analysis",
-                "reason": "run_head2head=False" if not cfg.run_head2head else "unavailable",
+                "reason": "run_head2head=False" if not cfg.analysis.run_head2head else "unavailable",
             },
         )
 
     hgb_mod = _optional_import("farkle.analysis.hgb_feat")
-    if cfg.run_hgb and hgb_mod is not None:
+    if cfg.analysis.run_hgb and hgb_mod is not None:
         hgb_mod.run(cfg)
     else:
         LOGGER.info(
             "Analytics: skipping hist gradient boosting",
             extra={
                 "stage": "analysis",
-                "reason": "run_hgb=False" if not cfg.run_hgb else "unavailable",
+                "reason": "run_hgb=False" if not cfg.analysis.run_hgb else "unavailable",
             },
         )
     LOGGER.info("Analytics: all modules finished", extra={"stage": "analysis"})


### PR DESCRIPTION
## Summary
- simplify the analysis pipeline entry point to accept only `AppConfig`
- reference run flags from `cfg.analysis` when invoking optional modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e229d432d8832f8f2e10df4b0303d9